### PR TITLE
退修问题修复

### DIFF
--- a/routes/other/home.js
+++ b/routes/other/home.js
@@ -5,7 +5,7 @@ homeRouter
 		const {data, db, query, nkcModules} = ctx;
 		// 删除退修超时的帖子
 		// 取出全部被标记的帖子
-		const allMarkThreads = await db.ThreadModel.find({ "recycleMark": true, "fid": { "$nin": ["recycle"] } });
+		const allMarkThreads = await db.ThreadModel.find({ "recycleMark": true, "mainForumsId": { "$nin": ["recycle"] } });
 		for (var i in allMarkThreads) {
 			const delThreadLog = await db.DelPostLogModel.findOne({ "postType": "thread", "threadId": allMarkThreads[i].tid, "toc": {$lt: Date.now() - 3*24*60*60*1000}})
 			if(delThreadLog){

--- a/routes/other/home.js
+++ b/routes/other/home.js
@@ -9,8 +9,8 @@ homeRouter
 		for (var i in allMarkThreads) {
 			const delThreadLog = await db.DelPostLogModel.findOne({ "postType": "thread", "threadId": allMarkThreads[i].tid, "toc": {$lt: Date.now() - 3*24*60*60*1000}})
 			if(delThreadLog){
-				await allMarkThreads[i].update({ "recycleMark": false, fid: "recycle" })
-				await db.PostModel.updateMany({"tid":allMarkThreads[i].tid},{$set:{"fid":"recycle"}})
+				await allMarkThreads[i].update({ "recycleMark": false, "mainForumsId": ["recycle"] })
+				await db.PostModel.updateMany({"tid":allMarkThreads[i].tid},{$set:{"mainForumsId":["recycle"]}})
 				await db.DelPostLogModel.updateMany({"postType": "thread", "threadId": allMarkThreads[i].tid},{$set:{"delType":"toRecycle"}})
         const tUser = await db.UserModel.findOne({uid: delThreadLog.delUserId});
         const thread = await db.ThreadModel.findOne({tid: delThreadLog.threadId});


### PR DESCRIPTION
问题描述：退修帖子持续未修改，三天后没有被送回回收站，而是正常出现。
原因：在之前修改板块架构时，未调整退修超时的帖子，在数据查询时使用的依然是fid，而不是新架构下的mainForumsId