### PR TITLE
修复

### DIFF
--- a/dataModels/ThreadModel.js
+++ b/dataModels/ThreadModel.js
@@ -1508,7 +1508,8 @@ threadSchema.methods.createNewPost = async function(post) {
     uid: post.uid,
     uidlm: post.uid,
     rpid
-  });
+  }); 
+  if(!this.oc) await this.update({oc: pid});
   await _post.save();
   // 由于需要将部分信息（是否存在引用）带到路由，所有将post转换成普通对象
   _post = _post.toObject();


### PR DESCRIPTION
在发表文章时，先生成了thread，此时thread上的oc字段为空。紧接着生成post，post生成后立即对内容中的at进行了匹配，并且生成@短消息，但是在拓展短消息内容时发生了错误。因为短消息上记录的是pid，需要通过pid拓展thread，但是此时thread的oc字段并无内容，最终导致thread为undefined，最后导致取thread上的tid报错。当前更新为临时处理办法，发表逻辑待优化。