### PR TITLE
修复

### DIFF
--- a/pages/forum/forum.js
+++ b/pages/forum/forum.js
@@ -1,6 +1,6 @@
 var SubscribeTypes;
 $(function() {
-  if(NKC.modules.SubscribeTypes) {
+  if(!window.SubscribeTypes && NKC.modules.SubscribeTypes) {
     SubscribeTypes = new NKC.modules.SubscribeTypes();
   }
   var dom = $("#navbar_custom_dom");

--- a/pages/home/home.js
+++ b/pages/home/home.js
@@ -16,7 +16,7 @@ var swiper = new Swiper('.swiper-container', {
 
 var SubscribeTypes;
 $(function() {
-  if(NKC.modules.SubscribeTypes)
+  if(!window.SubscribeTypes && NKC.modules.SubscribeTypes)
     SubscribeTypes = new NKC.modules.SubscribeTypes();
   
 });

--- a/pages/thread/index.js
+++ b/pages/thread/index.js
@@ -27,7 +27,7 @@ $(document).ready(function(){
   if(window.moduleToColumn) {
     moduleToColumn.init();
   }
-  if(NKC.modules.SubscribeTypes) {
+  if(!window.SubscribeTypes && NKC.modules.SubscribeTypes) {
     SubscribeTypes = new NKC.modules.SubscribeTypes();
   }
   if(NKC.modules.UserInfo) {

--- a/pages/user/user.js
+++ b/pages/user/user.js
@@ -7,7 +7,7 @@ $(function() {
   if(window.moduleToColumn) {
     moduleToColumn.init();
   }
-  if(NKC.modules.SubscribeTypes)
+  if(!window.SubscribeTypes && NKC.modules.SubscribeTypes)
     SubscribeTypes = new NKC.modules.SubscribeTypes();
 });
 function managementPosts() {


### PR DESCRIPTION
修复用户面板无法加载关注分类的问题。
仅修复了最新页、文章页、专业页、个人名片页。无法测试，可能有遗漏的地方。
更新步骤：
1. 更新代码；
2. 重启网站；