### PR TITLE
修复，添加

### DIFF
--- a/defaultData/settings/post.js
+++ b/defaultData/settings/post.js
@@ -21,6 +21,8 @@ module.exports = {
       survey: {
         status: false,
         defaultCertGradesId: [],
+        deadlineMax: 30,
+        ignoredRolesId: [],
         rolesId: [],
         uid: []
       },
@@ -48,6 +50,8 @@ module.exports = {
         status: false,
         defaultCertGradesId: [],
         rolesId: [],
+        deadlineMax: 30,
+        ignoredRolesId: [],
         uid: []
       }
     }

--- a/middlewares/body.js
+++ b/middlewares/body.js
@@ -41,6 +41,7 @@ module.exports = async (ctx, next) => {
       ctx.body = fs.createReadStream(filePath);
       ctx.set('Content-Length', stats.size);
     } else if(fileType !== "attachment" && rangeExt.includes(ext)) { // 音频、视频、pdf
+      ctx.set('Content-Disposition', `inline; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`);
       ctx.set("Accept-Ranges", "bytes");
       let createdStream = false;
       if(ctx.request.headers['range']){
@@ -69,62 +70,6 @@ module.exports = async (ctx, next) => {
       }
       ctx.set('Content-Length', stats.size);
     }
-    /*if(ext === "pdf") {
-      ctx.set("accept-ranges", "bytes");
-      console.log(1, ctx.request.headers['range'])
-    }
-    if(fileType !== "attachment" && ["mp4"].includes(ext)){
-      if(ctx.request.headers['range']){
-        var range = utils.parseRange(ctx.request.headers["range"], stats.size);
-        if(range){
-          ctx.set("Content-Range", "bytes " + range.start + "-" + range.end + "/" + stats.size);
-          ctx.set("Content-Length", (range.end - range.start + 1));
-          var stream = await fss.createReadStream(filePath, {
-            "start": range.start,
-            "end": range.end
-          });
-          // ctx.response.writeHead('206', "Partial Content");
-          ctx.status = 206;
-          ctx.body = stream;
-          // stream.pipe(ctx.response);
-        }else{
-          if(ctx.response) {
-            // ctx.response.removeHeader("Content-Length");
-            ctx.status = 416;
-            // ctx.response.end();
-          }
-        }
-      }else{
-
-        // ctx.response.writeHead('200', "Partial Content");
-        ctx.status = 200;
-        ctx.body = fss.createReadStream(filePath);
-        // stream.pipe(ctx.response);
-      }
-    }else{
-      if(fileType !== "attachment" && extArr.includes(ext)) {
-        ctx.set('Content-Disposition', `inline; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`);
-      } else {
-        ctx.set('Content-Disposition', `attachment; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`)
-      }
-      if(tg) {
-        ctx.body = fss.createReadStream(filePath).pipe(tg.throttle());
-      } else {
-        ctx.body = fss.createReadStream(filePath);
-      }
-      ctx.set('Content-Length', stats.size);
-    }*/
-    /*if(fileType !== "attachment" && extArr.includes(ext)) {
-      ctx.set('Content-Disposition', `inline; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`);
-    } else {
-      ctx.set('Content-Disposition', `attachment; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`)
-    }
-    if(tg) {
-      ctx.body = fss.createReadStream(filePath).pipe(tg.throttle());
-    } else {
-      ctx.body = fss.createReadStream(filePath);
-    }
-    ctx.set('Content-Length', stats.size);*/
     await next();
   } else {
     ctx.logIt = true; // if the request is request to a content, log it;

--- a/nkcModules/nkc_render.js
+++ b/nkcModules/nkc_render.js
@@ -621,9 +621,12 @@ function nkc_render(options){
         if(!resource) {
           return "（附件：" + plain_escape(v1) + "）";
         }
-        var resourceUrl = "/r/" + resource.rid;
+        var resourceUrl = "/r/" + resource.rid + "?t=attachment";
+        var readerLinkDom = "";
         if(resource.ext === "pdf") {
-          resourceUrl = tools.getUrl("pdf", resource.rid);
+          readerLinkDom = '<div class="article-attachment-reader"><a href="'+
+            tools.getUrl("pdf", resource.rid) +
+            '" target="_blank">预览</a></div>'
         }
         return '<div class="article-attachment">' +
           '<div class="article-attachment-icon">' +
@@ -637,6 +640,7 @@ function nkc_render(options){
               '<div class="article-attachment-size">'+getSize(resource.size)+'</div>' +
               '<div class="article-attachment-ext">'+(resource.ext||"").toUpperCase()+'</div>' +
               '<div class="article-attachment-hits">'+(resource.hits || 0)+'次下载</div>' +
+               readerLinkDom +
             '</div>' +
           '</div>' +
         '</div>'

--- a/pages/experimental/settings/post.js
+++ b/pages/experimental/settings/post.js
@@ -9,6 +9,7 @@ var app = new Vue({
     type: 'postToForum', // postToForum, postToThread, postResource, postLibrary
   },
   methods: {
+    checkNumber: NKC.methods.checkData.checkNumber,
     addUser: function(type) {
       var uid = this.uid;
       var this_ = this;
@@ -50,24 +51,33 @@ var app = new Vue({
     save: function() {
       var results = this.postSettings[this.type];
       var results_ = JSON.parse(JSON.stringify(results));
-      var exam = results_.exam;
-      results_.exam = {
-        volumeA: exam.indexOf('volumeA') !== -1,
-        volumeB: exam.indexOf('volumeB') !== -1,
-        notPass: {
-          status: exam.indexOf('notPass') !== -1,
-          unlimited: [true, 'true'].indexOf(results_.examCountLimit.unlimited) !== -1,
-          countLimit: Number(results_.examCountLimit.countLimit)
-        }
-      };
-      var obj = {
-        roles: app.roles,
-        grades: app.grades
-      };
-      delete results_.examCountLimit;
-      delete results_.authLevel;
-      obj[this.type] = results_;
-      nkcAPI('/e/settings/post', 'PATCH', obj)
+      var self = this;
+      Promise.resolve()
+        .then(function() {
+          var exam = results_.exam;
+          results_.exam = {
+            volumeA: exam.indexOf('volumeA') !== -1,
+            volumeB: exam.indexOf('volumeB') !== -1,
+            notPass: {
+              status: exam.indexOf('notPass') !== -1,
+              unlimited: [true, 'true'].indexOf(results_.examCountLimit.unlimited) !== -1,
+              countLimit: Number(results_.examCountLimit.countLimit)
+            }
+          };
+          var obj = {
+            roles: app.roles,
+            grades: app.grades
+          };
+          self.checkNumber(results_.survey.deadlineMax, {
+            name: "调查的最长天数",
+            min: 0.1,
+            fractionDigits: 1
+          });
+          delete results_.examCountLimit;
+          delete results_.authLevel;
+          obj[self.type] = results_;
+          return nkcAPI('/e/settings/post', 'PATCH', obj);
+        })
         .then(function() {
           screenTopAlert('保存成功');
         })

--- a/pages/experimental/settings/post.pug
+++ b/pages/experimental/settings/post.pug
@@ -227,6 +227,19 @@ block content
                       img(:src="'/avatar/' + user.avatar + '?t=sm'")
                       a(:href="'/u/' + user.uid"  target="_blank" title="访问用户主页") {{user.username}}
                       .fa.fa-remove(@click="removeUser(index, 'survey')" title="点击移除")
+                div.m-t-1 时间限制：
+                  div.m-l-2.m-t-05
+                    span 调查的最长时间不能超过
+                    input(type="text" v-model.number="postSettings[type].survey.deadlineMax")
+                    | 天
+                  div.m-l-2.m-t-05
+                    span 拥有以下已勾选证书的用户不受限制
+                    div
+                      <label class="mdui-checkbox mdui-m-r-2" v-for="role, index in roles">
+                      <input type="checkbox" :value="role._id" v-model='postSettings[type].survey.ignoredRolesId'/>
+                      <i class="mdui-checkbox-icon"></i>
+                      | {{role.displayName}}
+                      </label>
                 hr
             .row(v-if="type === 'postToForum'")
               .col-sm-2.text-right

--- a/pages/external_pkgs/viewer/jquery-viewer.js
+++ b/pages/external_pkgs/viewer/jquery-viewer.js
@@ -1,0 +1,73 @@
+/*!
+ * jQuery Viewer v1.0.1
+ * https://fengyuanchen.github.io/jquery-viewer
+ *
+ * Copyright 2018-present Chen Fengyuan
+ * Released under the MIT license
+ *
+ * Date: 2019-12-14T09:00:02.315Z
+ */
+
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery'), require('viewerjs')) :
+  typeof define === 'function' && define.amd ? define(['jquery', 'viewerjs'], factory) :
+  (global = global || self, factory(global.jQuery, global.Viewer));
+}(this, (function ($, Viewer) { 'use strict';
+
+  $ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+  Viewer = Viewer && Viewer.hasOwnProperty('default') ? Viewer['default'] : Viewer;
+
+  if ($ && $.fn && Viewer) {
+    var AnotherViewer = $.fn.viewer;
+    var NAMESPACE = 'viewer';
+
+    $.fn.viewer = function jQueryViewer(option) {
+      for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+        args[_key - 1] = arguments[_key];
+      }
+
+      var result;
+      this.each(function (i, element) {
+        var $element = $(element);
+        var isDestroy = option === 'destroy';
+        var viewer = $element.data(NAMESPACE);
+
+        if (!viewer) {
+          if (isDestroy) {
+            return;
+          }
+
+          var options = $.extend({}, $element.data(), $.isPlainObject(option) && option);
+          viewer = new Viewer(element, options);
+          $element.data(NAMESPACE, viewer);
+        }
+
+        if (typeof option === 'string') {
+          var fn = viewer[option];
+
+          if ($.isFunction(fn)) {
+            result = fn.apply(viewer, args);
+
+            if (result === viewer) {
+              result = undefined;
+            }
+
+            if (isDestroy) {
+              $element.removeData(NAMESPACE);
+            }
+          }
+        }
+      });
+      return result !== undefined ? result : this;
+    };
+
+    $.fn.viewer.Constructor = Viewer;
+    $.fn.viewer.setDefaults = Viewer.setDefaults;
+
+    $.fn.viewer.noConflict = function noConflict() {
+      $.fn.viewer = AnotherViewer;
+      return this;
+    };
+  }
+
+})));

--- a/pages/fund/apply/editForm.pug
+++ b/pages/fund/apply/editForm.pug
@@ -251,25 +251,8 @@ block fundContent
 
 block fundScripts
   if data.s === 5
-    +includeCSS("/external_pkgs/viewer/viewer.css")
-    +includeJS("/external_pkgs/viewer/viewer.js")
     include ../../publicModules/lazySizes
-    script.
-      $(document).ready(function () {
-        var options = {
-          navbar: false,
-          title: false,
-          toolbar: false
-        }
-        const applicationFormDom = document.getElementById("applicationForm");
-        const applicationFormCommentDom = document.getElementById('applicationForm-comments');
-        if(applicationFormDom) {
-          new Viewer(applicationFormDom, options);
-        }
-        if(applicationFormCommentDom) {
-          new Viewer(applicationFormCommentDom, options);
-        }
-      })
+    include ../../publicModules/imageViewer
   include  ../../publicModules/selectForum/selectForum
   include  ../../publicModules/selectResource/selectResource
   include ../../publicModules/strToHTML

--- a/pages/fund/fundBase.pug
+++ b/pages/fund/fundBase.pug
@@ -2,7 +2,6 @@ extends ../bootstrap_base
 block title
   +includeCSS("/fund.css")
   +includeCSS("/fund/fund.css")
-  +includeCSS("/external_pkgs/viewer/main.css")
   block fundTitle
 block content
   .container-fluid.max-width.fund

--- a/pages/interface_fund_audit.pug
+++ b/pages/interface_fund_audit.pug
@@ -357,4 +357,5 @@ block content
 block scripts
   include ./publicModules/lazySizes
   include ./publicModules/plyr/plyr.js.pug
+  include ./publicModules/imageViewer
   +includeJS('/interface_fund_audit.js')

--- a/pages/nkc_styles.css
+++ b/pages/nkc_styles.css
@@ -3961,6 +3961,10 @@ ul.nav.navbar-nav.navbar-md>li>a{
   color: #e85a71;
   font-weight: 700;
 }
+.article-attachment-reader{
+  color: #2b90d9;
+  font-weight: 700;
+}
 .article-audio{
   box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.14);
   border-radius: 2px;

--- a/pages/post/post.pug
+++ b/pages/post/post.pug
@@ -27,8 +27,6 @@ block title
   meta(name='keywords' content=`${thread.firstPost.t}`)
   link(rel='stylesheet' href=`/post/post.css?v=${global.NKC.startTime}`)
   link(rel='stylesheet' href=`/external_pkgs/imageToBig/preview.css?v=${global.NKC.startTime}`)
-  +includeCSS("/external_pkgs/viewer/viewer.css")
-  +includeCSS("/external_pkgs/viewer/main.css")
   +includeJS("/external_pkgs/imageToBig/preview.js")
   include ../publicModules/plyr/plyr.css.pug
 block content
@@ -162,7 +160,7 @@ block scripts
   include ../ueditor/ueditorBase
   include ../MathJax.pug
   +includeJS(`/thread/comments.js`)
-  +includeJS("/external_pkgs/viewer/viewer.js")
+  include ../publicModules/imageViewer
   if permission("getPostAuthor")
     include ../publicModules/floatUserPanel/userInfo
   script.
@@ -175,12 +173,6 @@ block scripts
     var UserInfo;
     $(document).ready(function() {
       if(NKC.modules.UserInfo) UserInfo = new NKC.modules.UserInfo();
-      var options = {
-        navbar: false,
-        title: false,
-        toolbar: false,
-      }
-      new Viewer(document.getElementById('ThreadPostBody'), options);
       NKC.methods.markDom($(".highlight-dom>.highlight"));
       NKC.methods.scrollToDom($(".highlight-dom"));
     })

--- a/pages/publicModules/imageViewer.pug
+++ b/pages/publicModules/imageViewer.pug
@@ -1,0 +1,18 @@
+if !state.isApp
+  +includeCSS("/external_pkgs/viewer/viewer.css")
+  +includeCSS("/external_pkgs/viewer/main.css")
+  +includeJS("/external_pkgs/viewer/viewer.js")
+  +includeJS("/external_pkgs/viewer/jquery-viewer.js")
+  script.
+    $(document).ready(function() {
+      var options = {
+        navbar: false,
+        title: false,
+        toolbar: false,
+      }
+      $(".article-img-body").viewer(options);
+      $("#productImageDom").viewer(options);
+      $("#pikeImpor").viewer(options);
+      $("#applicationForm").viewer(options);
+      $("#applicationForm-comments").viewer(options);
+    })

--- a/pages/publicModules/survey/edit.js
+++ b/pages/publicModules/survey/edit.js
@@ -5,6 +5,7 @@ NKC.modules.SurveyEdit = function() {
     el: "#moduleSurveyEdit",
     data: {
       disabled: true,
+      deadlineMax: "",
       targetUser: "",
       survey: "",
       newSurvey: "",
@@ -98,8 +99,9 @@ NKC.modules.SurveyEdit = function() {
         ],
         type: 'vote'
       };
-      nkcAPI("/survey", "GET")
+      nkcAPI("/survey?t=thread", "GET")
         .then(function(data) {
+          this_.deadlineMax = data.deadlineMax;
           this_.grades = data.grades;
           var arr = [];
           for(var i = 0; i < data.grades.length; i++) {

--- a/pages/publicModules/survey/edit.pug
+++ b/pages/publicModules/survey/edit.pug
@@ -237,6 +237,7 @@
                 -for(var i = 0; i < 60; i++)
                   option(value=i)=i
               | &nbsp;分
+              h5.text-danger(v-if="deadlineMax") 调查时间不能超过{{deadlineMax}}天。
       //-.form-group
         label.col-sm-2.control-label
         .col-sm-9

--- a/pages/thread/index.pug
+++ b/pages/thread/index.pug
@@ -30,8 +30,6 @@ block title
     meta(name='keywords' content=`${thread.firstPost.t}`)
     link(rel='stylesheet' href=`/external_pkgs/imageToBig/preview.css?v=${global.NKC.startTime}`)
     +includeCSS("/jquery-ui-1.10.4.custom.css")
-    +includeCSS("/external_pkgs/viewer/viewer.css")
-    +includeCSS("/external_pkgs/viewer/main.css")
     +includeJS("/external_pkgs/imageToBig/preview.js")
     include ../publicModules/plyr/plyr.css.pug
   if !state.isApp
@@ -703,24 +701,5 @@ block scripts
   +includeJS("/thread/comments.js")
   if permission("getPostAuthor")
     include ../publicModules/floatUserPanel/userInfo
-  +includeJS("/external_pkgs/viewer/viewer.js")
-  if !state.isApp
-    script.
-      $(document).ready(function() {
-        var options = {
-          navbar: false,
-          title: false,
-          toolbar: false,
-        }
-        new Viewer(document.getElementById('ThreadPostBody'), options);
-        if($("#productImageDom").length === 0) {
-          new Viewer(document.getElementById('thread-content'), options);
-        }else{
-          new Viewer(document.getElementById('productImageDom'), options);
-          new Viewer(document.getElementById('pikeImpor'), options);
-          new Viewer(document.getElementById('productIntroDom'), options);
-          new Viewer(document.getElementById('productInfoContent'), options);
-        }
-        //- new Viewer(document.getElementById('pikeLook'), options);
-      })
+  include ../publicModules/imageViewer
   +includeJS("/thread/index.js")

--- a/routes/forum/singleForum.js
+++ b/routes/forum/singleForum.js
@@ -82,7 +82,8 @@ router
       const havePermission = await db.SurveyModel.ensureCreatePermission("postToForum", user.uid);
       if(!havePermission) ctx.throw(403, "你没有权限发起调查，请刷新");
       survey.uid = data.user.uid;
-      surveyDB = await db.SurveyModel.createSurvey(survey);
+      survey.postType = "thread";
+      surveyDB = await db.SurveyModel.createSurvey(survey, true);
       options.surveyId = surveyDB._id;
     }
 		const _post = await db.ThreadModel.postNewThread(options);

--- a/routes/post/index.js
+++ b/routes/post/index.js
@@ -395,6 +395,11 @@ router
     // 修改调查表
     if(survey && targetPost.surveyId) {
       survey.mid = data.user.uid;
+      if(targetThread.oc === pid) {
+        survey.postType = "thread";
+      } else {
+        survey.postType = "post";
+      }
       await db.SurveyModel.modifySurvey(survey);
     }
     let newAuthInfos = [];

--- a/routes/resource/index.js
+++ b/routes/resource/index.js
@@ -93,7 +93,9 @@ resourceRouter
       ctx.set('Cache-Control', `public, max-age=${cache.maxAge}`)
     }
     // 在resource中添加点击次数
-    await resource.update({$inc:{hits:1}});
+    if(!ctx.request.headers['range']){
+      await resource.update({$inc:{hits:1}});
+    }
     
     ctx.filePath = filePath;
     // 表明客户端希望以附件的形式加载资源

--- a/routes/survey/index.js
+++ b/routes/survey/index.js
@@ -3,25 +3,22 @@ const router = new Router();
 const surveyRouter = require("./singleSurvey");
 router
   .get("/", async (ctx, next) => {
-    const {data, db} = ctx;
+    const {data, db, query} = ctx;
+    const {t} = query;
     const {user} = data;
     data.grades = await db.UsersGradeModel.find().sort({_id: 1});
     data.roles = await db.RoleModel.find({_id: {$nin: ["visitor", "banned"]}});
-    /*const survey = db.SurveyModel({
-      type: "vote",
-      uid: user.uid,
-      pid: "0",
-      mid: user.uid,
-      st: Date.now(),
-      et: Date.now()
-    });
-    delete survey._id;
-    delete survey.uid;
-    delete survey.mid;
-    delete survey.et;
-    delete survey.st;
-    data.survey = survey;
-    console.log(data.survey)*/
+    const postSettings = await db.SettingModel.getSettings("post");
+    let surveySettings;
+    if(t === "thread") {
+      surveySettings = postSettings.postToForum.survey;
+    } else {
+      surveySettings = postSettings.postToThread.survey;
+    }
+    const deadlineMax = await db.SurveyModel.getDeadlineMax(t, data.user.uid);
+    if(deadlineMax) {
+      data.deadlineMax = deadlineMax;
+    }
     await next();
   })
   .post("/", async (ctx, next) => {
@@ -30,9 +27,7 @@ router
     const {survey} = body;
     survey.uid = user.uid;
     survey.mid = user.mid;
-    console.log(survey);
     await db.SurveyModel.createSurvey(survey);
-    console.log(s);
     await next();
   })
   .use("/:surveyId", surveyRouter.routes(), surveyRouter.allowedMethods());


### PR DESCRIPTION
1. 修复pdf阅读器内下载文件没有预制文件名的问题；
2. 文章页内针对pdf的附件条添加预览按钮；
3. 添加调查时间限制，后台可配置；
4. 修复文章页查看图片时可能出现的错乱问题；
5. 修复因视频、音频以及pdf文件分段加载导致文件下载次数被多次统计的问题；

更新步骤
1. 关闭网站
2. 更新代码；
3. 执行脚本`script.js`（添加调查时间限制的相关设置）；
4. 启动网站；
5. 后台管理>发表>发表文章，设置`发起调查`中的`时间限制`。
    a. 设置上限时间；
    b. 勾选不受限制的证书；