### PR TITLE
修复

### DIFF
--- a/dataModels/MessageModel.js
+++ b/dataModels/MessageModel.js
@@ -124,7 +124,7 @@ messageSchema.statics.ensureSystemLimitPermission = async (uid, tUid) => {
     uid,
     reviewed: true,
     disabled: false,
-    recycleMark: false,
+    recycleMark: {$ne: true},
     mainForumsId: {$ne: "recycle"}
   });
   if(userThreadCount < threadCount) throwErr(403, mandatoryLimitInfo);


### PR DESCRIPTION
1. 修复统计老用户发帖数量始终为0导致无法发送短消息的问题；

更新步骤
1. 更新代码；
2. 重启网站；