### PR TITLE
调整

### DIFF
--- a/dataModels/UserModel.js
+++ b/dataModels/UserModel.js
@@ -664,7 +664,7 @@ userSchema.statics.createUser = async (option) => {
 	const MessageModel = mongoose.model('messages');
 	const SubscribeTypeModel = mongoose.model("subscribeTypes");
 	const SystemInfoLogModel = mongoose.model('systemInfoLogs');
-
+  const serverSettings = await SettingModel.getSettings('server');
 	const userObj = Object.assign({}, option);
 
 	const toc = Date.now();
@@ -681,7 +681,7 @@ userSchema.statics.createUser = async (option) => {
 	userObj.certs = [];
 	// 生成默认用户名，符号"-"和uid保证此用户名全局唯一
 	if(!userObj.username) {
-	  userObj.username = `kc-${uid}`;
+	  userObj.username = `${serverSettings.websiteCode}-${uid}`;
     userObj.usernameLowerCase = userObj.username;
   }
 

--- a/defaultData/settings/server.js
+++ b/defaultData/settings/server.js
@@ -3,6 +3,7 @@ module.exports = {
   c: {
     websiteName: '科创',
     websiteAbbr: '科创',
+    websiteCode: 'kc',
     serverName: 'nkc $ server',
     telephone: '00000000',
     github: 'https://github.com/kccd/nkc.git',

--- a/middlewares/body.js
+++ b/middlewares/body.js
@@ -73,41 +73,6 @@ module.exports = async (ctx, next) => {
     ctx.set('Content-Disposition', contentDisposition);
     ctx.set(`Content-Length`, contentLength);
 
-
-    /*if(fileType !== "attachment" && extArr.includes(ext)) { // 图片
-      ctx.set('Content-Disposition', `inline; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`);
-      ctx.body = fs.createReadStream(filePath);
-      ctx.set('Content-Length', stats.size);
-    } else if(fileType !== "attachment" && rangeExt.includes(ext)) { // 音频、视频、pdf
-      ctx.set('Content-Disposition', `inline; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`);
-      ctx.set("Accept-Ranges", "bytes");
-      let createdStream = false;
-      if(ctx.request.headers['range']){
-        const range = utils.parseRange(ctx.request.headers["range"], stats.size);
-        if(range){
-          ctx.body = await fss.createReadStream(filePath, {
-            start: range.start,
-            end: range.end
-          });
-          ctx.set("Content-Range", "bytes " + range.start + "-" + range.end + "/" + stats.size);
-          ctx.set("Content-Length", (range.end - range.start + 1));
-          createdStream = true;
-          ctx.status = 206;
-        }
-      }
-      if(!createdStream) {
-        ctx.body = await fss.createReadStream(filePath);
-        ctx.set("Content-Length", stats.size);
-      }
-    } else { // 附件
-      ctx.set('Content-Disposition', `attachment; filename=${encodeRFC5987ValueChars(name)}; filename*=utf-8''${encodeRFC5987ValueChars(name)}`)
-      if(tg) {
-        ctx.body = fss.createReadStream(filePath).pipe(tg.throttle());
-      } else {
-        ctx.body = fss.createReadStream(filePath);
-      }
-      ctx.set('Content-Length', stats.size);
-    }*/
     await next();
   } else {
     ctx.logIt = true; // if the request is request to a content, log it;

--- a/pages/exam/paper.pug
+++ b/pages/exam/paper.pug
@@ -1,6 +1,6 @@
 extends ../bootstrap_base
 block title
-  title 科创会员专业知识测验
+  title=`${state.serverSettings.websiteName}会员专业知识测验`
   +includeCSS('/exam/exam.css')
 block content
   .container-fluid.max-width#app(v-if='category && paper' v-cloak)
@@ -24,7 +24,7 @@ block content
     .row(v-else)
       .col-xs-12.col-md-3
         img(src=tools.getUrl('siteFile', 'holy_exam.gif'))
-        h3 科创会员专业知识测验
+        h3=`${state.serverSettings.websiteName}会员专业知识测验`
         h5 今日考试次数剩余：{{countOneDay - countToday + 1}} 次
         h5 考试科目：{{category.name + ' ' + {'A':'基础级', 'B': '专业级'}[category.volume]}}
         h5 开考时间：{{format('YYYY-MM-DD HH:mm:ss', paper.toc)}}

--- a/pages/experimental/settings/base.pug
+++ b/pages/experimental/settings/base.pug
@@ -21,6 +21,10 @@ block content
             .col-sm-8
               input.form-control(type='text' v-model="serverSettings.websiteAbbr")
           .form-group
+            label.col-sm-2.control-label 网站代号
+            .col-sm-8
+              input.form-control(type='text' v-model="serverSettings.websiteCode")
+          .form-group
             label.col-sm-2.control-label github
             .col-sm-8
               input.form-control(type='text' v-model="serverSettings.github")

--- a/pages/home/home.pug
+++ b/pages/home/home.pug
@@ -5,10 +5,11 @@ block title
   +includeCSS("/home/home.css")
 
 block content
+  -const reg = new RegExp(`^${state.serverSettings.websiteCode}-`);
   -const canManagement = permission("superModerator");
   .container-fluid.max-width
     .row
-      if data.user && (/^kc-/.test(data.user.username) || !data.user.username)
+      if data.user && (reg.test(data.user.username) || !data.user.username)
         .col-xs-12.m-b-1
           .home-warning
             .fa.fa-exclamation-circle

--- a/pages/problem/add_problem.pug
+++ b/pages/problem/add_problem.pug
@@ -38,7 +38,7 @@ block content
           .form-group
             button.btn.btn-primary.btn-block#submit 提交
           .form-group
-            h4=`科创论坛值班室：${state.serverSettings.telephone}`
-            
+            h4=`${state.serverSettings.websiteName}值班室：${state.serverSettings.telephone}`
+
 block scripts
   +includeJS("/problem/add_problem.js")

--- a/pages/publicModules/improveUserInfo.pug
+++ b/pages/publicModules/improveUserInfo.pug
@@ -1,5 +1,5 @@
 if data.user
-  -let reg = /^kc-/;
+  -let reg = new RegExp(`^${state.serverSettings.websiteCode}-`);
   -const unsetUsername = reg.test(data.user.username) || !data.user.username;
   if unsetUsername || !data.user.setPassword || !data.user.boundEmail || !data.user.boundMobile || !data.user.avatar || !data.user.banner || !data.user.description
     .improve.m-t-1.m-b-1

--- a/pages/publicModules/login/login.pug
+++ b/pages/publicModules/login/login.pug
@@ -92,7 +92,7 @@
                     .fa.fa-exclamation-circle
                     span {{error}}
                 .text-left.m-b-1(style="font-size:1rem" v-if="type === 'register'") 注册即代表同意
-                  a(href=`/protocol?type=register` target="_blank") 《科创统一服务协议（注册协议）》
+                  a(href=`/protocol?type=register` target="_blank")=`《${state.serverSettings.websiteName}统一服务协议（注册协议）》`
                 .text-right
                   .pull-left.link(v-if="type === 'login'")
                     a(@click="selectType('register')") 注册

--- a/routes/experimental/settings/base/index.js
+++ b/routes/experimental/settings/base/index.js
@@ -9,13 +9,15 @@ baseRouter
 	})
 	.put('/', async (ctx, next) => {
 		const {db, body} = ctx;
-		let {links, websiteName, websiteAbbr, github, backgroundColor, copyright, record, description, keywords, brief, telephone, statement} = body;
+		let {links,websiteCode ,websiteName, websiteAbbr, github, backgroundColor, copyright, record, description, keywords, brief, telephone, statement} = body;
 		if(!websiteName) ctx.throw(400, '网站名不能为空');
+		if(!websiteCode) ctx.throw(400, `网站代号不能为空`);
 		websiteName = websiteName.trim();
 		const serverSettings = await db.SettingModel.findOnly({_id: 'server'});
 		const keywordsArr = keywords.split(',');
 		const obj = {
 		  c: {
+				websiteCode,
 				websiteName,
 				websiteAbbr,
         github,

--- a/routes/experimental/settings/user/index.js
+++ b/routes/experimental/settings/user/index.js
@@ -81,6 +81,7 @@ userRouter
     const {uid} = params;
     const targetUser = await db.UserModel.findOnly({uid});
     const targetUsersPersonal = await db.UsersPersonalModel.findOnly({uid});
+    const serverSettings = await db.SettingModel.getSettings('server');
     // 用户名重名检测
     if(username) {
       if(targetUser.username !== username) {
@@ -91,7 +92,7 @@ userRouter
         if(sameNameColumn) ctx.throw(400, "用户名与专栏名冲突，请更换");
       }
     } else {
-      username = `kc-${targetUser.uid}`;
+      username = `${serverSettings.websiteCode}-${targetUser.uid}`;
     }
     // 邮箱检测
     if(targetUsersPersonal.email !== email) {

--- a/routes/user/clear.js
+++ b/routes/user/clear.js
@@ -5,6 +5,7 @@ router
     const {settings, db, body, params, nkcModules} = ctx;
     const {uid} = params;
     const targetUser = await db.UserModel.findOnly({uid});
+    const serverSettings = await db.SettingModel.getSettings('server');
     const {type} = body;
     const time = Date.now();
     if(type === "avatar") {
@@ -12,7 +13,7 @@ router
     } else if(type === "banner") {
       await nkcModules.file.deleteUserBanner(targetUser.uid);
     } else if(type === "username") {
-      const newUsername = `kc-${targetUser.uid}`;
+      const newUsername = `${serverSettings.websiteCode}-${targetUser.uid}`;
       const newUsernameLowerCase = newUsername.toLowerCase();
       await db.SecretBehaviorModel({
         operationId: "modifyUsername",


### PR DESCRIPTION
1. 替换所有kc、科创关键字；
2. 优化附件的断点续传；

故园 更新步骤
1. 更新代码；
2. 关闭网站；
3. 执行脚本`modifyHomeSettings.js`，将默认用户名前缀改为gy（可在 后台管理-设置-基本-网站代号 中设置）；
4. 执行脚本`modifyResourceSizeExtension.js`，修复附件格式、尺寸信息；