### PR TITLE
修复

### DIFF
--- a/nkcModules/sendMessage/tencentCloud.js
+++ b/nkcModules/sendMessage/tencentCloud.js
@@ -18,7 +18,7 @@ module.exports = async (smsSettings, obj) => {
         }
       }
     };
-    const params = [code, timeout + ''];
+    const params = [code];
     sSender.sendWithParam(nationCode?parseInt(nationCode):86, mobile, templateId, params, smsSign, "", "", callback);
   });
 }


### PR DESCRIPTION
修复腾讯云短信接口调用错误的问题；

更新代码
1. 更新代码；
2. 重启网站；

可只更新科创，故园下次一起更新。