### PR TITLE
修复，调整

### DIFF
--- a/dataModels/ForumModel.js
+++ b/dataModels/ForumModel.js
@@ -1680,7 +1680,8 @@ forumSchema.statics.saveAllForumsToRedis = async () => {
   for(const _forum of forums) {
     const forum = _forum.toObject();
     const key = getRedisKeys(`forumData`, forum.fid);
-    await client.setAsync(key, JSON.stringify(forum));
+    await client.setAsJsonString(key, forum);
+    // await client.setAsync(key, JSON.stringify(forum));
   }
   // 保存所有专业的id到redis
   await ForumModel.saveAllForumsIdToRedis(forums);
@@ -1743,13 +1744,12 @@ forumSchema.statics.saveAllForumsIdToRedis = async (forums) => {
       }
     }
   }
-  const key = getRedisKeys(`forumsId`);
-  await client.resetSetAsync(key, forumsId);
-  await client.resetSetAsync(getRedisKeys('accessibleForumsId'), accessibleForumsId);
-  await client.resetSetAsync(getRedisKeys('visibilityForumsId'), visibilityForumsId);
-  await client.resetSetAsync(getRedisKeys('isVisibilityNCCForumsId'), isVisibilityNCCForumsId);
-  await client.resetSetAsync(getRedisKeys('displayOnParentForumsId'), displayOnParentForumsId);
-  await client.resetSetAsync(getRedisKeys('displayOnSearchForumsId'), displayOnSearchForumsId);
+  await client.setArray(getRedisKeys(`forumsId`), forumsId);
+  await client.setArray(getRedisKeys('accessibleForumsId'), accessibleForumsId);
+  await client.setArray(getRedisKeys('visibilityForumsId'), visibilityForumsId);
+  await client.setArray(getRedisKeys('isVisibilityNCCForumsId'), isVisibilityNCCForumsId);
+  await client.setArray(getRedisKeys('displayOnParentForumsId'), displayOnParentForumsId);
+  await client.setArray(getRedisKeys('displayOnSearchForumsId'), displayOnSearchForumsId);
 };
 /*
 * 从redis获取所有专业的id
@@ -1757,8 +1757,7 @@ forumSchema.statics.saveAllForumsIdToRedis = async (forums) => {
 * @author pengxiguaa 2020/8/25
 * */
 forumSchema.statics.getAllForumsIdFromRedis = async () => {
-  const key = getRedisKeys('forumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(getRedisKeys('forumsId'));
 };
 
 /*
@@ -1772,9 +1771,8 @@ forumSchema.statics.getAllForumsFromRedis = async () => {
   const forums = [];
   for(const fid of forumsId) {
     const key = getRedisKeys(`forumData`, fid);
-    let forum = await client.getAsync(key);
+    const forum = await client.getFromJsonString(key);
     if(!forum) continue;
-    forum = JSON.parse(forum);
     forums.push(forum);
   }
   return forums;
@@ -1791,7 +1789,7 @@ forumSchema.statics.saveForumToRedis = async (fid) => {
   if(!forum) throwErr(500, `专业不存在 fid: ${fid}`);
   forum = forum.toObject();
   const key = getRedisKeys('forumData', forum.fid);
-  await client.setAsync(key, JSON.stringify(forum));
+  await client.setAsJsonString(key, forum);
   await ForumModel.saveAllForumsIdToRedis();
 };
 
@@ -1803,8 +1801,7 @@ forumSchema.statics.saveForumToRedis = async (fid) => {
 * */
 forumSchema.statics.getForumByIdFromRedis = async (fid) => {
   const key = getRedisKeys(`forumData`, fid);
-  const forum = await client.getAsync(key);
-  return forum? JSON.parse(forum): null;
+  return await client.getFromJsonString(key);
 };
 
 
@@ -2051,7 +2048,7 @@ forumSchema.statics.getWritableForumsIdByUid = async (uid) => {
 * */
 forumSchema.statics.getAccessibleForumsIdFromRedis = async () => {
   const key = getRedisKeys('accessibleForumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(key);
 };
 /*
 * 获取导航可见的专业ID
@@ -2060,7 +2057,7 @@ forumSchema.statics.getAccessibleForumsIdFromRedis = async () => {
 * */
 forumSchema.statics.getVisibilityForumsIdFromRedis = async () => {
   const key = getRedisKeys('visibilityForumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(key);
 };
 /*
 * 获取无权用户导航可见的专业ID
@@ -2069,7 +2066,7 @@ forumSchema.statics.getVisibilityForumsIdFromRedis = async () => {
 * */
 forumSchema.statics.getIsVisibilityNCCForumsIdFromRedis = async () => {
   const key = getRedisKeys('isVisibilityNCCForumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(key);
 };
 /*
 * 获取可在上层专业显示文章的专业ID
@@ -2078,7 +2075,7 @@ forumSchema.statics.getIsVisibilityNCCForumsIdFromRedis = async () => {
 * */
 forumSchema.statics.getDisplayOnParentForumsIdFromRedis = async () => {
   const key = getRedisKeys('displayOnParentForumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(key);
 };
 /*
 * 获取可在搜索页显示文章的专业ID
@@ -2087,7 +2084,7 @@ forumSchema.statics.getDisplayOnParentForumsIdFromRedis = async () => {
 * */
 forumSchema.statics.getDisplayOnSearchForumsIdFromRedis = async () => {
   const key = getRedisKeys('displayOnSearchForumsId');
-  return await client.smembersAsync(key);
+  return await client.getArray(key);
 };
 
 

--- a/defaultData/settings/download.js
+++ b/defaultData/settings/download.js
@@ -14,6 +14,7 @@ module.exports = {
         fileCountOneDay: 3,
         speed: 1024, // KB
       }
-    ]
+    ],
+    allSpeed: 100 * 1024, //总下载速度 KB
   }
 };

--- a/nkcModules/render.js
+++ b/nkcModules/render.js
@@ -8,6 +8,7 @@ moment.locale('zh-cn');
 const languages = require('../languages');
 const tools = require("./tools");
 const htmlFilter = require('./nkcRender/htmlFilter');
+const hexToRgba = require('hex-to-rgba');
 
 let filters = {
   markdown:render.commonmark_render,
@@ -379,6 +380,7 @@ let pugRender = (template, data, state) => {
 		getOriginLevel: getOriginLevel,
     server: settings.server,
     plain:render.plain_render,
+		hexToRgba,
     experimental_render:render.experimental_render,
 		nkcRender,
     replaceContent: replaceContent,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "urllib": "^0.5.2",
     "vue": "^2.5.16",
     "xbbcode-parser": "^0.1.2",
+    "hex-to-rgba": "^2.0.1",
     "xss": "^1.0.3"
   },
   "devDependencies": {

--- a/pages/experimental/settings/download.js
+++ b/pages/experimental/settings/download.js
@@ -2,13 +2,15 @@ var data = NKC.methods.getDataById("data");
 var app = new Vue({
   el: "#app",
   data: {
+    downloadSettings: data.downloadSettings,
     roleOptions: data.roleOptions,
     gradeOptions: data.gradeOptions
   },
   methods: {
     submit: function() {
       nkcAPI("/e/settings/download", "PUT", {
-        options: this.roleOptions.concat(this.gradeOptions)
+        options: this.roleOptions.concat(this.gradeOptions),
+        allSpeed: this.downloadSettings.allSpeed
       })
         .then(function() {
           sweetSuccess("保存成功");

--- a/pages/experimental/settings/download.pug
+++ b/pages/experimental/settings/download.pug
@@ -3,7 +3,7 @@ block eTitle
   title 下载设置
 block eContent
   .container-fluid.max-width
-    #data.hidden=objToStr({roleOptions: data.roleOptions, gradeOptions: data.gradeOptions})
+    #data.hidden=objToStr({roleOptions: data.roleOptions, gradeOptions: data.gradeOptions, downloadSettings: data.downloadSettings})
     .row#app(v-cloak)
       .col-xs-12.col-md-12.table-responsive
         table.table.table-striped
@@ -12,31 +12,35 @@ block eContent
               th 证书
               th 每天下载附件个数
               th 下载速度限制
-          tbody 
+          tbody
             tr(v-for="o in roleOptions")
               th {{o.name}}
-              th 
+              th
                 input(type="text" v-model.number="o.fileCountOneDay")
               th
                 input(type="text" v-model.number="o.speed")
                 span &nbsp;KB
-        h4 用户等级（普通会员）        
+        h4 用户等级（普通会员）
         table.table.table-striped
           thead
             tr
               th 证书
               th 每天下载附件个数
               th 下载速度限制
-          tbody 
+          tbody
             tr(v-for="o in gradeOptions")
               th {{o.name}}
-              th 
+              th
                 input(type="text" v-model.number="o.fileCountOneDay")
               th
                 input(type="text" v-model.number="o.speed")
-                span &nbsp;KB   
-        .m-t-1
-          button.btn.btn-primary(@click="submit") 保存
+                span &nbsp;KB
 
+      .col-xs-12.col-md-12
+        span.h4 总下载速度：
+        input(type='text' v-model.number='downloadSettings.allSpeed').m-r-05
+        span KB / 进程
+      .col-xs-12.col-md-12.m-t-1
+        button.btn.btn-primary(@click="submit") 保存
 block scripts
-  +includeJS("/experimental/settings/download.js")    
+  +includeJS("/experimental/settings/download.js")

--- a/pages/home/home_all.css
+++ b/pages/home/home_all.css
@@ -68,6 +68,19 @@ body {
 .home-forums .home-forums-list {
   background-color: #fff;
 }
+.home-forums .home-forums-list .home-forums-brief {
+  display: inline-block;
+  font-size: 1.3rem;
+  margin: 0 0.3rem 0.5rem 0;
+}
+.home-forums .home-forums-list .home-forums-brief .home-forums-parent {
+  color: #333;
+  font-weight: 700;
+}
+.home-forums .home-forums-list .home-forums-brief .home-forums-child {
+  color: #333;
+  margin: 0 0.3rem;
+}
 .home-forums .home-forums-list .home-forums-body {
   padding: 0.3rem;
 }

--- a/pages/home/home_all.less
+++ b/pages/home/home_all.less
@@ -59,6 +59,20 @@ body{
 .home-forums{
   .home-forums-list{
     background-color: #fff;
+    .home-forums-brief{
+      display: inline-block;
+      font-size: 1.3rem;
+      margin: 0 0.3rem 0.5rem 0;
+      .home-forums-parent{
+        color: #333;
+        font-weight: 700;
+      }
+      .home-forums-child{
+        color: #333;
+        margin: 0 0.3rem;
+        //background-color: #dbeef3;
+      }
+    }
     .home-forums-body{
       padding: 0.3rem;
       &:hover{

--- a/pages/home/home_all.pug
+++ b/pages/home/home_all.pug
@@ -5,6 +5,16 @@ block title
   +includeCSS("/swiper/dist/css/swiper.css")
 block content
   mixin forumList(f)
+    .home-forums-brief
+      a.home-forums-parent(href=`/f/${f.fid}` data-float-fid=f.fid)=f.displayName
+      if f.childrenForums
+        span ：
+        for cf, index in f.childrenForums
+          if index !== 0
+            span |
+          //-style=`background-color: ${f.color}`
+          a.home-forums-child(href=`/f/${cf.fid}` data-float-fid=cf.fid style=`background-color: ${hexToRgba(f.color, 0.1)}`)=cf.displayName
+  mixin forumList_1(f)
     .home-forums-body
       .home-forum-parent
         a(href=`/f/${f.fid}` data-float-fid=f.fid).home-forum-panel

--- a/pages/publicModules/common.js
+++ b/pages/publicModules/common.js
@@ -336,15 +336,7 @@ NKC.methods.ipUrl = function(ip) {
 * @author pengxiguaa 2019-8-27
 * */
 NKC.methods.getSize = function(size, digits) {
-  if(digits === undefined) digits = 2;
-  if(size < 1024*1024) {
-    size = (size/1024).toFixed(digits) + "KB";
-  } else if(size < 1024*1024*1024) {
-    size = (size/(1024*1024)).toFixed(digits) + "MB";
-  } else {
-    size = (size/(1024*1024*1024)).toFixed(digits) + "GB";
-  }
-  return size;
+  return NKC.methods.tools.getSize(size, digits);
 };
 /*
 * 获取随机颜色

--- a/pages/publicModules/selectResource/selectResource.css
+++ b/pages/publicModules/selectResource/selectResource.css
@@ -345,3 +345,10 @@
   background-position: center center;
   background-repeat: no-repeat;
 }
+#moduleSelectResourceApp .size-limit{
+  margin-left: 0.5rem;
+  font-size: 1rem;
+}
+#moduleSelectResourceApp .size-limit .fa{
+  color: #555;
+}

--- a/pages/publicModules/selectResource/selectResource.pug
+++ b/pages/publicModules/selectResource/selectResource.pug
@@ -108,6 +108,8 @@
             button.btn.btn-default.btn-sm(v-if='isApp' @click="recordAudio") 录音
             //-button.btn.btn-default.btn-sm(@click="crash") 刷新
             #pasteContent.text-left.hidden-xs.hidden-sm(@click="readyPaste") 剪贴板上传，先点一下我，再 Ctrl+V 黏贴。
+            span.size-limit.hidden-xs.hidden-sm(@click='showFileSizeLimit' :title='fileSizeLimit' v-if='fileSizeLimit') 大小限制
+              .fa.fa-question-circle
           //button(type="button" class="btn btn-default btn-sm" @click="close") 关闭
           button(type="button" class="btn btn-primary btn-sm" v-if="!selectedResourcesId.length" disabled title="请先勾选图片") 确定
           button(type="button" class="btn btn-primary btn-sm" @click="done" v-else) 确定

--- a/routes/experimental/settings/download/index.js
+++ b/routes/experimental/settings/download/index.js
@@ -39,12 +39,13 @@ router
       option.name = grade.displayName;
       data.gradeOptions.push(option);
     });
+    data.downloadSettings = downloadSettings;
 		ctx.template = 'experimental/settings/download.pug';
 		await next();
 	})
 	.put('/', async (ctx, next) => {
     const {db, body, nkcModules} = ctx;
-    const {options} = body;
+    const {options, allSpeed} = body;
     const options_ = [];
     const {checkNumber} = nkcModules.checkData;
     for(const option of options) {
@@ -66,14 +67,19 @@ router
       }
       options_.push({
         type,
-        id, 
+        id,
         fileCountOneDay,
         speed
       });
     }
+    checkNumber(allSpeed, {
+      name: '总下载速度',
+      min: 0,
+    });
     await db.SettingModel.updateOne({_id: "download"}, {
       $set: {
-        "c.options": options_
+        "c.options": options_,
+        'c.allSpeed': allSpeed
       }
     });
     await db.SettingModel.saveSettingsToRedis("download");

--- a/routes/me/index.js
+++ b/routes/me/index.js
@@ -17,13 +17,13 @@ meRouter
     quota = parseInt(quota);
     skip = parseInt(skip);
     let queryMap;
-    if(type == "all") {
+    if(type === "all") {
       queryMap = {"uid": user.uid};
-    }else if(type == "picture") {
+    }else if(type === "picture") {
       queryMap = {"uid": user.uid, "mediaType": "mediaPicture"};
-    }else if(type == "video") {
+    }else if(type === "video") {
       queryMap = {"uid": user.uid, "mediaType": "mediaVideo"};
-    }else if(type == "audio") {
+    }else if(type === "audio") {
       queryMap = {"uid": user.uid, "mediaType": "mediaAudio"};
     }else{
       queryMap = {"uid": user.uid, "mediaType": "mediaAttachment"};
@@ -49,6 +49,8 @@ meRouter
     }
     ctx.data.maxSkip = maxSkip;
     ctx.data.resources = await db.ResourceModel.find(queryMap).sort({toc: -1}).skip(newSkip).limit(quota);
+    const uploadSettings = await db.SettingModel.getSettings('upload');
+    data.sizeLimit = uploadSettings.sizeLimit;
     await next();
   })
 	.get('/life_photos', async (ctx, next) => {

--- a/settings/redisClient.js
+++ b/settings/redisClient.js
@@ -19,6 +19,32 @@ Redis.RedisClient.prototype.resetSetAsync = async function(key, values = []) {
     await this.delAsync(key);
   }
 };
+/*
+* 存JSON
+* */
+Redis.RedisClient.prototype.setAsJsonString = async function(key, data) {
+  await this.setAsync(key, JSON.stringify(data));
+};
+/*
+* 取JSON
+* */
+Redis.RedisClient.prototype.getFromJsonString = async function(key) {
+  const data = await this.getAsync(key);
+  return data? JSON.parse(data): null;
+};
+/*
+* 存数组JSON
+* */
+Redis.RedisClient.prototype.setArray = async function(key, data = []) {
+  await this.setAsJsonString(key, data);
+};
+/*
+* 取数组JSON
+* */
+Redis.RedisClient.prototype.getArray = async function(key) {
+  return await this.getFromJsonString(key) || [];
+};
+
 
 const redisConfig = require('../config/redis');
 const client = Redis.createClient({


### PR DESCRIPTION
1. 修复专业选择器顺序错乱的问题；
2. 前端添加对上传文件大小的检测；
3. 添加总体下载速度限制；
4. 调整主页专业列表样式；

更新步骤
1. 更新代码；
2. 关闭网站；
3. 执行代码`modifyDownloadSettings.js`；
4. 执行node server.js建立缓存；
5. 故园执行cnpm i，科创执行npm i;
5. ctrl+c，pm2 启动网站；
6. 后台管理，下载设置，设置整体下载速度；