### PR TITLE
临时屏蔽pdf预览功能

### DIFF
--- a/routes/resource/index.js
+++ b/routes/resource/index.js
@@ -76,7 +76,7 @@ resourceRouter
           }
         } else if(c === "preview_pdf") {
           const pdfPath = await resource.getPDFPreviewFilePath();
-          if(!await nkcModules.file.access(pdfPath)) nkcModules.throwError(403, `当前文档暂不能预览`, 'previewPDF');
+          if(1 || !await nkcModules.file.access(pdfPath)) nkcModules.throwError(403, `当前文档暂不能预览`, 'previewPDF');
           const referer = ctx.get('referer');
           if(referer.includes('/reader/pdf/web/viewer')) {
             filePath = pdfPath;

--- a/routes/resource/methods/mediaAttachment.js
+++ b/routes/resource/methods/mediaAttachment.js
@@ -21,7 +21,7 @@ module.exports = async (options) => {
     state: 'usable'
   });
   // 如果是pdf就再生成一个预览版
-  if(ext.toLowerCase() === "pdf") {
+  if(0 && ext.toLowerCase() === "pdf") {
     let pdfPreviewPath = PATH.resolve(fileFolder, `./${rid}_preview.${ext}`);
     // console.log("预览版pdf生成到:", pdfPreviewPath);
     const {error} = await pdfPreviewWorker.makeFile({


### PR DESCRIPTION
临时屏蔽预览功能，更新后，上传pdf文件不再生成预览文件。
此操作对nkc没有影响，但会影响到ngy的pdf预览功能。

更新步骤
1. 更新代码；
2. 重启网站；