### PR TITLE
修复

### DIFF
--- a/pages/publicModules/plyr/plyr.js.pug
+++ b/pages/publicModules/plyr/plyr.js.pug
@@ -40,8 +40,9 @@ script.
         });
         if(!isVideo) {
           player.download = "/r/" + rid + "?d=attachment";
+        } else {
+          addEvents(player, dom);
         }
-        addEvents(player, dom);
         player.speed = 1;
         NKC.methods.initPlyrMask(player);
         players.push(player);


### PR DESCRIPTION
修复音频下载链接组装错误的问题

科创、故园更新步骤：
1. 更新代码；
2. pm2 reload nkc，只需要重启nkc服务即可；