### PR TITLE
修复

### DIFF
--- a/pages/interface_fund_complete.js
+++ b/pages/interface_fund_complete.js
@@ -26,7 +26,7 @@ function getThreads(page, self) {
 	$('.unselectedThreads').html(html);
 	nkcAPI(url, 'GET', {})
 		.then(function(data) {
-			tempThreads = data.threads;
+			const tempThreads = data.threads;
 			var paging = data.paging;
 			displayPageList(paging, self);
 			if(tempThreads.length === 0) {
@@ -35,7 +35,7 @@ function getThreads(page, self) {
 			displayThreadsList('.unselectedThreads', tempThreads, false, 'add');
 		})
 		.catch(function(data) {
-			screenTopWarning(data.error);
+			sweetError(data);
 			var html = '<div class="blank blank-selectedThread">error</div>';
 			$('.unselectedThreads').html(html);
 		})


### PR DESCRIPTION
修复基金结题无法加载自己文章列表的问题

更新步骤
1. 更新代码；
2. 在项目根目录执行 `npm run build-pages-p`；
3. 重启网站；