### PR TITLE
修复

### DIFF
--- a/nkcModules/nkcRender/index.js
+++ b/nkcModules/nkcRender/index.js
@@ -197,7 +197,8 @@ class NKCRender {
     if(count < textLength) text += "...";
     return text;
   }
-  replaceLink(data = '') {
+  replaceLink() {
+    data = data || '';
     return data.replace(urlReg, (c) => {
       if(domainWhitelistReg.test(c)) {
         return c;


### PR DESCRIPTION
修复链接过滤导致页面报错问题

更新步骤
1. 更新代码；
2. 重启网站；