### PR TITLE
修复，优化

### DIFF
--- a/dataModels/AliPayRecordModel.js
+++ b/dataModels/AliPayRecordModel.js
@@ -276,6 +276,7 @@ schema.statics.transfer = async (props) => {
   } catch(err) {
     record.status = 'failed';
     record.fullData = JSON.stringify({error: err.toString()});
+    record.note = err.toString();
   }
   await record.save();
   if(record.status === 'failed') {

--- a/dataModels/FundApplicationFormModel.js
+++ b/dataModels/FundApplicationFormModel.js
@@ -571,10 +571,17 @@ fundApplicationFormSchema.methods.extendThreads = async function() {
 fundApplicationFormSchema.methods.extendSupporters = async function() {
 	const UserModel = mongoose.model('users');
 	const supporters = [];
-	for(let uid of this.supportersId) {
-		const user = await UserModel.findOnly({uid});
-		supporters.push(user);
-	}
+  const users = await UserModel.find({uid: {$in: this.supportersId}});
+  const usersObj = {};
+  for(const user of users) {
+    usersObj[user.uid] = user;
+  }
+  for(const uid of this.supportersId) {
+    const user = usersObj[uid];
+    if(user && !supporters.includes(user)) {
+      supporters.push(user);
+    }
+  }
 	return this.supporters = supporters;
 };
 

--- a/dataModels/ResourceModel.js
+++ b/dataModels/ResourceModel.js
@@ -596,10 +596,25 @@ resourceSchema.methods.checkUserScore = async function(user) {
 * */
 resourceSchema.methods.updateForumsId = async function() {
   const PostModel = mongoose.model('posts');
+  const LibraryModel = mongoose.model('libraries');
+  const ForumModel = mongoose.model('forums');
   const posts = await PostModel.find({pid: {$in: this.references}}, {mainForumsId: 1});
   let forumsId = [];
   for(const post of posts) {
     forumsId = forumsId.concat(post.mainForumsId);
+  }
+  const files = await LibraryModel.find({
+    type: 'file',
+    rid: this.rid,
+  });
+  if(files.length > 0) {
+    const foldersId = [];
+    for(const file of files) {
+      const nav = await file.getNav();
+      foldersId.push(nav[0]);
+    }
+    const forums = await ForumModel.find({lid: {$in: foldersId}}, {fid: 1});
+    forumsId = forumsId.concat(forums.map(f => f.fid));
   }
   forumsId = [...new Set(forumsId)];
   this.forumsId = forumsId;

--- a/dataModels/ShopGoodsModel.js
+++ b/dataModels/ShopGoodsModel.js
@@ -477,5 +477,39 @@ shopGoodsSchema.statics.computeSellCount = async (productId) => {
   }
 };
 
+/*
+* 更新商品图
+* */
+shopGoodsSchema.methods.updateResources = async function(resourcesId) {
+  const ResourceModel = mongoose.model('resources');
+  const {imgIntroductions, productId} = this;
+  console.log(this);
+  if(imgIntroductions.length > 0) {
+    await ResourceModel.updateMany({
+      rid: {$in: imgIntroductions},
+      references: `shop-${productId}`
+    }, {
+      $pull: {
+        references: `shop-${productId}`
+      }
+    });
+  }
+  this.imgIntroductions = resourcesId;
+  this.imgMaster = resourcesId[0];
+  await this.updateOne({
+    $set: {
+      imgIntroductions: this.imgIntroductions,
+      imgMaster: this.imgMaster
+    }
+  });
+  await  ResourceModel.updateMany({
+    rid: {$in: resourcesId}
+  }, {
+    $addToSet: {
+      references: `shop-${productId}`
+    }
+  });
+}
+
 const ShopGoodsModel = mongoose.model('shopGoods', shopGoodsSchema);
 module.exports = ShopGoodsModel;

--- a/dataModels/ShopGoodsModel.js
+++ b/dataModels/ShopGoodsModel.js
@@ -483,7 +483,6 @@ shopGoodsSchema.statics.computeSellCount = async (productId) => {
 shopGoodsSchema.methods.updateResources = async function(resourcesId) {
   const ResourceModel = mongoose.model('resources');
   const {imgIntroductions, productId} = this;
-  console.log(this);
   if(imgIntroductions.length > 0) {
     await ResourceModel.updateMany({
       rid: {$in: imgIntroductions},

--- a/languages/zh_cn/operations.json
+++ b/languages/zh_cn/operations.json
@@ -802,6 +802,5 @@
   "experimentalIPSettings": "后台管理 - IP 黑名单",
   "experimentalShareSettings": "后台管理 - 分享设置",
   "experimentalToolsFilter": "后台管理 - 工具 - 敏感词检测",
-  "experimentalFilterLogs": "查看后台敏感词过滤记录",
-  "withdrawFundApplicationForm": ""
+  "experimentalFilterLogs": "查看后台敏感词过滤记录"
 }

--- a/languages/zh_cn/operations.json
+++ b/languages/zh_cn/operations.json
@@ -294,6 +294,7 @@
   "restoreFundApplicationForm": "恢复被放弃的基金申请",
   "stopFundApplicationForm": "强制终止基金申请",
   "timeoutFundApplicationForm": "强制设置基金申请修改超时",
+  "withdrawFundApplicationForm": "强制撤回基金申请",
   "visitGiveUpFundApplicationList": "查看被放弃的基金申请",
   "visitUserBills": "查看用户有关基金的账单",
   "submitInformation": "注册成功后提交用户名和密码",
@@ -801,5 +802,6 @@
   "experimentalIPSettings": "后台管理 - IP 黑名单",
   "experimentalShareSettings": "后台管理 - 分享设置",
   "experimentalToolsFilter": "后台管理 - 工具 - 敏感词检测",
-  "experimentalFilterLogs": "查看后台敏感词过滤记录"
+  "experimentalFilterLogs": "查看后台敏感词过滤记录",
+  "withdrawFundApplicationForm": ""
 }

--- a/pages/experimental/settings/sensitiveWords/sensitiveWords.js
+++ b/pages/experimental/settings/sensitiveWords/sensitiveWords.js
@@ -184,14 +184,19 @@ var app = new Vue({
       var group = this.keywordSetting.wordGroup[groupIndex];
       var content = group.keywords.join("\n");
       var downloader = document.createElement("a");
-      downloader.setAttribute("href", "data:text/plain;charset=utf-8," + content);
+      downloader.style.display = 'none';
+      var blob = new Blob([content]);
+      // downloader.setAttribute("href", "data:text/plain;charset=utf-8," + content);
+      downloader.setAttribute("href", URL.createObjectURL(blob));
       downloader.setAttribute("download", "敏感词组_" + group.name + ".txt");
+      document.body.appendChild(downloader);
       downloader.click();
+      document.body.removeChild(downloader);
     },
     // 应用到所有专业
     applyAllForums: function(groupIndex) {
       var id = self.keywordSetting.wordGroup[groupIndex].id;
-      sweetConfirm("确定要将这个词组应用到所有专业吗?")
+      sweetQuestion("确定要将这个词组应用到所有专业吗?")
       .then(function() {
         return nkcAPI("/e/settings/review/keyword", "PUT", {
           type: "applyAllForums",
@@ -199,9 +204,23 @@ var app = new Vue({
         })
       })
       .then(function() {
-        sweetAlert("成功");
+        sweetSuccess("执行成功");
       })
       .catch(sweetError);
+    },
+    cancelApplyAllForums: function(groupIndex) {
+      const id = self.keywordSetting.wordGroup[groupIndex].id;
+      sweetQuestion(`确定要取消应用到所有专业吗？`)
+        .then(function() {
+          return nkcAPI(`/e/settings/review/keyword`, 'PUT', {
+            type: 'cancelApplyAllForums',
+            value: id
+          })
+        })
+        .then(function() {
+          sweetSuccess('执行成功');
+        })
+        .catch(sweetError);
     },
     // 关键字搜索框
     searchWordInputChange: function(el, groupIndex) {

--- a/pages/experimental/settings/sensitiveWords/sensitiveWords.pug
+++ b/pages/experimental/settings/sensitiveWords/sensitiveWords.pug
@@ -68,11 +68,12 @@ block eContent
                           span.conditions-times(contenteditable="true" @focus="startEdit($event.target)" @blur="endEdit($event.target, group, 'times')") {{group.conditions.times}}
                           |次敏感词
                       th
-                        button.btn.btn-danger.btn-xs(href="javascript:void(0);" @click="deleteWordGroup(groupIndex)") 删除
-                        button.btn.btn-default.btn-xs(href="javascript:void(0);" @click="group.rename = !group.rename") {{group.rename ? "取消重命名" : "重命名"}}
-                        button.btn.btn-default.btn-xs(href="javascript:void(0);" @click="addKeyword(groupIndex)") 添加
-                        button.btn.btn-default.btn-xs(href="javascript:void(0);" @click="exportWordGroup(groupIndex)") 导出
-                        button.btn.btn-primary.btn-xs(href="javascript:void(0);" @click="applyAllForums(groupIndex)") 应用到所有专业
+                        button.m-b-05.btn.btn-default.btn-xs(@click="group.rename = !group.rename") {{group.rename ? "取消重命名" : "重命名"}}
+                        button.m-b-05.btn.btn-default.btn-xs(@click="addKeyword(groupIndex)") 添加
+                        button.m-b-05.btn.btn-default.btn-xs(@click="exportWordGroup(groupIndex)") 导出
+                        button.m-b-05.btn.btn-default.btn-xs(@click="applyAllForums(groupIndex)") 应用到所有专业
+                        button.m-b-05.btn.btn-danger.btn-xs(@click="cancelApplyAllForums(groupIndex)") 取消应用到所有专业
+                        button.m-b-05.btn.btn-danger.btn-xs(@click="deleteWordGroup(groupIndex)") 删除
                     tr(v-show="group.keywordView")
                       th(colspan="4")
                         .keyword-search

--- a/pages/fund/remittance/audit.js
+++ b/pages/fund/remittance/audit.js
@@ -14,13 +14,14 @@ function ensureRemittance(id, number) {
 }
 
 function withdrawApplicationForm(id) {
-  return sweetQuestion(`确定要执行此操作？`)
-    .then(() => {
-      return nkcAPI('/fund/a/'+id+'?type=withdraw', 'DELETE', {})
+  return sweetPrompt(`请输入撤回原因`, '')
+    .then((reason) => {
+      return nkcAPI(`/fund/a/${id}/manage/withdraw`, 'POST', {
+        reason
+      })
     })
     .then(function(data) {
-      // window.location.href = '/fund/a/'+data.applicationForm._id;
-      openToNewLocation('/fund/a/'+data.applicationForm._id);
+      sweetSuccess(`执行成功`);
     })
     .catch(function(data) {
       sweetError(data);

--- a/pages/fund/remittance/audit.pug
+++ b/pages/fund/remittance/audit.pug
@@ -16,6 +16,11 @@ block fundContent
             h5 收款方式：银行卡
           h5= `户名：${applicationForm.account.name}`
           h5= `收款账号：${applicationForm.account.number}`
+          if applicationForm.remittance[0].status !== true
+            .bg-danger.p-a-1.text-danger
+              button.btn.btn-sm.btn-danger(onclick=`withdrawApplicationForm(${applicationForm._id})`) 强制撤回
+              .m-t-05 强制撤回后，申请表可再次编辑，提交后可正常进入审核流程。
+
 
           hr
           h4 总共&nbsp;

--- a/pages/nkc_styles.less
+++ b/pages/nkc_styles.less
@@ -2898,6 +2898,7 @@ img.emoji {
 .thread-title{
   font-size: 30px;
   margin-top: 0;
+  word-break: break-word;
   margin-bottom: 1rem;
   font-weight: 700;
 }

--- a/routes/experimental/settings/review/index.js
+++ b/routes/experimental/settings/review/index.js
@@ -224,6 +224,13 @@ router
           "reviewSettings.keyword.rule.reply.useGroups": value
         }
       });
+    } else if(type === "cancelApplyAllForums") {
+      await db.ForumModel.updateMany({}, {
+        $pull: {
+          "reviewSettings.keyword.rule.thread.useGroups": value,
+          "reviewSettings.keyword.rule.reply.useGroups": value
+        }
+      });
     } else {
       ctx.throw(403, "参数不正确");
     }

--- a/routes/fund/application/manage/index.js
+++ b/routes/fund/application/manage/index.js
@@ -4,10 +4,12 @@ const restoreRouter = require('./restore');
 const auditRouter = require('./audit');
 const stopRouter = require('./stop');
 const timeoutRouter = require('./timeout');
+const withdrawRouter = require('./withdraw');
 router
   .use('/refuse', refuseRouter.routes(), refuseRouter.allowedMethods())
   .use('/restore', restoreRouter.routes(), restoreRouter.allowedMethods())
   .use('/audit', auditRouter.routes(), auditRouter.allowedMethods())
   .use('/stop', stopRouter.routes(), stopRouter.allowedMethods())
   .use('/timeout', timeoutRouter.routes(), timeoutRouter.allowedMethods())
+  .use('/withdraw', withdrawRouter.routes(), withdrawRouter.allowedMethods())
 module.exports = router;

--- a/routes/fund/application/manage/withdraw.js
+++ b/routes/fund/application/manage/withdraw.js
@@ -1,0 +1,26 @@
+const router = require('koa-router')();
+router
+  .post('/', async (ctx, next) => {
+    const {data, nkcModules, state, body} = ctx;
+    const {fund, applicationForm} = data;
+    const {reason} = body;
+    nkcModules.checkData.checkString(reason, {
+      name: '原因',
+      minLength: 1,
+      maxLength: 5000
+    });
+    if(
+      !await fund.isFundRole(state.uid, 'admin') &&
+      !await fund.isFundRole(state.uid, 'financialStaff')
+    ) ctx.throw(403, `权限不足`);
+    if(applicationForm.remittance[0].status === true) ctx.throw(400, '无法撤回已拨款的基金申请');
+    await applicationForm.updateOne({
+      'lock.submitted': false,
+      'status.usersSupport': null,
+      'status.projectPassed': null,
+      'status.adminSupport': null
+    });
+    await applicationForm.createReport('system', `申请已被撤回\n原因：${reason}`, state.uid, false);
+    await next();
+  });
+module.exports = router;

--- a/routes/shop/manage/shelf.js
+++ b/routes/shop/manage/shelf.js
@@ -312,6 +312,7 @@ shelfRouter
         await db.ShopProductsParamModel(param).save();
       }
       await product.save();
+      await product.updateResources(imgIntroductions);
       if(productStatus === "insale") {
         await product.onshelf();
       }
@@ -319,8 +320,6 @@ shelfRouter
       // 修改已上架的商品
       await product.updateOne({
         purchaseLimitCount,
-        imgIntroductions,
-        imgMaster,
         stockCostMethod,
         uploadCert,
         uploadCertDescription,
@@ -330,6 +329,7 @@ shelfRouter
         vipDisGroup,
         productSettings
       });
+      await product.updateResources(imgIntroductions);
       for(let i = 0; i < productParams.length; i++) {
         const param = productParams[i];
         const {

--- a/settings/operations/fund.js
+++ b/settings/operations/fund.js
@@ -126,6 +126,9 @@ module.exports = {
         },
         timeout: {
 			    POST: 'timeoutFundApplicationForm'
+        },
+        withdraw: {
+          POST: 'withdrawFundApplicationForm'
         }
       },
 			/*comment: {


### PR DESCRIPTION
1. 修复基金申请支持者用户名重复显示的问题；
2. 修复商品图无法显示的问题；
3. 修复文库文件下载报权限不足的问题；
4. 修复支付宝提现报错问题；
5. 修复基金申请审核通过后无法强制撤回的问题；
6. 优化敏感词；

更新步骤
1. 更新代码；
2. 在项目根目录执行 `npm run build-pages-p`；
3. 重启网站；
4. 执行脚本 `modifyFundAndShop.js`；
5. 后台管理 - 设置 - 证书，将 `强制撤回基金申请` 配置给普通用户（路由内有权限判断）； 
