### PR TITLE
修复

### DIFF
--- a/dataModels/QuestionModel.js
+++ b/dataModels/QuestionModel.js
@@ -111,8 +111,10 @@ schema.statics.extendQuestions = async (questions) => {
 * @param {Number} qid 试题 ID
 * */
 schema.methods.updateImage = async function(file) {
+  const FILE = require('../nkcModules/file');
   const {path} = file;
   const {_id} = this;
+  await FILE.getFileExtension(file, ['jpg', 'jpeg', 'png']);
   const {questionImagePath} = require('../settings/upload');
   const {questionImageify} = require('../tools/imageMagick');
   const targetPath = questionImagePath + '/' + _id + '.jpg';

--- a/routes/exam/question.js
+++ b/routes/exam/question.js
@@ -110,7 +110,6 @@ router
       public: publicQuestion,
       content,
       answer,
-      hasImage: false
     };
     if(auth === false) {
       // 提交自己审核不通过的试题时，试题会再次变为"待审核"状态。


### PR DESCRIPTION
1. 修复题库图片未限制格式的问题；
2. 修复编辑试题可能导致的丢失图片的问题；

更新步骤
1. 更新代码；
2. 重启网站；