### PR TITLE
Bugfix/es_host

### DIFF
--- a/settings/elasticSearch.js
+++ b/settings/elasticSearch.js
@@ -5,7 +5,7 @@ const {address, port} = esConfig;
 
 module.exports = () => {
   return new ES.Client({
-    node: address + ":" + port,
+    host: address + ":" + port,
     requestTimeout: 90000,
     apiVersion: '6.8'
   });

--- a/settings/redis.js
+++ b/settings/redis.js
@@ -50,7 +50,7 @@ const redisConfig = require('../config/redis');
 
 module.exports = () => {
   return Redis.createClient({
-    host: redisConfig.host,
+    host: redisConfig.address,
     port: redisConfig.port,
     db: redisConfig.db
   });


### PR DESCRIPTION
ElasticSearch and Redis are not using configured host and port to create client instances.