### PR TITLE
优化

### DIFF
--- a/dataModels/ForumModel.js
+++ b/dataModels/ForumModel.js
@@ -1067,6 +1067,21 @@ forumSchema.statics.getAllChildrenFid = async function(fid) {
 forumSchema.methods.getAllChildForumsId = async function() {
   return await client.smembersAsync(`forum:${this.fid}:allChildForumsId`);
 };
+/*
+* 获取专业下所有底层专业id
+* @return 专业id数组
+* */
+forumSchema.methods.getAllBottomLayerChildForumsId = async function() {
+  const forums = await this.getAllChildForums();
+  const forumsId = [];
+  for(const f of forums) {
+    const childForumsId = await f.getAllChildForumsId();
+    if(childForumsId.length !== 0) continue;
+    forumsId.push(f.fid);
+  }
+  if(forumsId.length === 0) forumsId.push(this.fid);
+  return forumsId;
+};
 
 forumSchema.statics.getAllChildForumsIdByFid = async function(fid) {
   return await client.smembersAsync(`forum:${fid}:allChildForumsId`);
@@ -1082,7 +1097,7 @@ forumSchema.statics.getAllChildForumsIdByFid = async function(fid) {
 forumSchema.methods.getAllChildForums = async function() {
   const ForumModel = mongoose.model('forums');
   const allChildForumsId = await this.getAllChildForumsId();
-  const forums = await ForumModel.find({fid: {$in: allChildForumsId}});
+  const forums = await ForumModel.find({fid: {$in: allChildForumsId}}).sort({order: 1});
   return this.allChildForums = forums;
 }
 /*

--- a/dataModels/RoleModel.js
+++ b/dataModels/RoleModel.js
@@ -270,10 +270,10 @@ roleSchema.statics.extendRole = async (_id) => {
 * */
 roleSchema.statics.getCertList = async (blacklist = []) => {
 	blacklist.push('default');
-	const RM = mongoose.model("roles");
-	const GM = mongoose.model("usersGrades");
-	const roles = await RM.find({_id: {$nin: blacklist}}, {_id: 1, displayName: 1}).sort({toc: 1});
-	const grades = await GM.find({}, {_id: 1, displayName: 1}).sort({_id: 1});
+	const RoleModel = mongoose.model("roles");
+	const UsersGradeModel = mongoose.model("usersGrades");
+	const roles = await RoleModel.find({_id: {$nin: blacklist}}, {_id: 1, displayName: 1}).sort({toc: 1});
+	const grades = await UsersGradeModel.find({}, {_id: 1, displayName: 1}).sort({_id: 1});
 	const data = [];
 	for(const role of roles) {
 		data.push({

--- a/defaultData/config/server.json
+++ b/defaultData/config/server.json
@@ -2,6 +2,7 @@
   "address": "0.0.0.0",
   "port": 9000,
   "domain": "http://127.0.0.1:9000",
+  "reserveDomain": [],
   "maxIpsCount": 1,
   "proxy": false,
   "domainWhitelist": [

--- a/defaultData/settings/visit.js
+++ b/defaultData/settings/visit.js
@@ -3,8 +3,13 @@ module.exports = {
   c: {
     globalAccessLimit: {
       status: false,
-      description: "暂不对普通会员开放",
-      whitelist: []
+      userDescription: "暂不对普通会员开放",
+      visitorDescription: '暂不对游客开放',
+      whitelist: {
+        rolesId: [],
+        gradesId: [],
+        relation: 'or', // or and
+      }
     },
     globalLimitVisitor: {
       status: false,

--- a/defaultData/settings/visit.js
+++ b/defaultData/settings/visit.js
@@ -1,6 +1,11 @@
 module.exports = {
   _id: 'visit',
   c: {
+    globalAccessLimit: {
+      status: false,
+      description: "暂不对普通会员开放",
+      whitelist: []
+    },
     globalLimitVisitor: {
       status: false,
       description: '暂不对游客开放，请登录或注册。'

--- a/languages/zh_cn/operations.json
+++ b/languages/zh_cn/operations.json
@@ -815,5 +815,6 @@
   "refundFundApplicationForm": "基金管理员确认退款",
   "experimentalThreadCategorySettings": "后台管理 - 设置 - 文章多维分类",
   "getWatermark": "获取水印图片",
-  "getAppsWatermark": "获取用户偏好设置水印"
+  "getAppsWatermark": "获取用户偏好设置水印",
+  "getForumChildForums": "获取专业下的子专业信息"
 }

--- a/middlewares/filterDomain.js
+++ b/middlewares/filterDomain.js
@@ -1,14 +1,17 @@
 const {
   domain,
+  reserveDomain = []
 } = require('../config/server');
 const {fileDownload} = require('../settings/operationsType');
 const domainHost = new URL(domain).host;
+const reserveDomainHost = reserveDomain.map(d => new URL(d).host)
 module.exports = async (ctx, next) => {
   const operationId = ctx.data.operationId;
 
   if(
     !global.NKC.isDevelopment &&
     domainHost !== ctx.host &&
+    !reserveDomainHost.includes(ctx.host) &&
     !fileDownload.includes(operationId)
   ) {
     ctx.status = 404;

--- a/pages/experimental/settings/visit/visit.js
+++ b/pages/experimental/settings/visit/visit.js
@@ -3,7 +3,8 @@ const app = new Vue({
   el: '#app',
   data: {
     visitSettings: data.visitSettings,
-    certList: data.certList
+    roles: data.roles,
+    grades: data.grades
   },
   methods: {
     submit() {

--- a/pages/experimental/settings/visit/visit.js
+++ b/pages/experimental/settings/visit/visit.js
@@ -2,7 +2,8 @@ const data = NKC.methods.getDataById('data');
 const app = new Vue({
   el: '#app',
   data: {
-    visitSettings: data.visitSettings
+    visitSettings: data.visitSettings,
+    certList: data.certList
   },
   methods: {
     submit() {

--- a/pages/experimental/settings/visit/visit.pug
+++ b/pages/experimental/settings/visit/visit.pug
@@ -4,10 +4,36 @@ block eTitle
 block eContent
   .container-fluid.max-width
     .row
-      .hidden#data= objToStr({visitSettings: data.visitSettings})
+      .hidden#data= objToStr({visitSettings: data.visitSettings, certList: data.certList})
       .col-xs-12.col-md-12#app(v-cloak)
         .form-horizontal
-          h4 全局游客限制
+          h4 全局访问限制
+          .form-group
+            label.col-sm-2.control-label 状态
+            .col-sm-10
+              .radio
+                label.m-r-1
+                  input(type="radio" v-model="visitSettings.globalAccessLimit.status" :value="true")
+                  | 开启
+                label
+                  input(type="radio" v-model="visitSettings.globalAccessLimit.status" :value="false")
+                  | 关闭
+          .form-group
+            label.col-sm-2.control-label 白名单
+            .col-sm-6
+              .checkbox
+                label.m-r-05
+                  input(type='checkbox' disabled checked="true")
+                  span 证书 - 运维
+                label.m-r-05(v-for='cl in certList')
+                  input(type='checkbox' v-model="visitSettings.globalAccessLimit.whitelist" :value='cl.type')
+                  span {{cl.name}}
+          .form-group
+            label.col-sm-2.control-label 提示内容
+            .col-sm-6
+              textarea.form-control(rows=5 v-model="visitSettings.globalAccessLimit.description")
+              span.text-info 支持空格和换行
+          h4 游客全局访问限制
           .form-group
             label.col-sm-2.control-label 状态
             .col-sm-10
@@ -24,7 +50,7 @@ block eContent
             .col-sm-6
               textarea.form-control(rows=5 v-model="visitSettings.globalLimitVisitor.description")
               span.text-info 支持空格和换行
-          h4 用户名片页游客限制
+          h4 游客用户名片页访问限制
           .form-group
             label.col-sm-2.control-label 状态
             .col-sm-10

--- a/pages/experimental/settings/visit/visit.pug
+++ b/pages/experimental/settings/visit/visit.pug
@@ -4,7 +4,7 @@ block eTitle
 block eContent
   .container-fluid.max-width
     .row
-      .hidden#data= objToStr({visitSettings: data.visitSettings, certList: data.certList})
+      .hidden#data= objToStr({visitSettings: data.visitSettings, roles: data.roles, grades: data.grades})
       .col-xs-12.col-md-12#app(v-cloak)
         .form-horizontal
           h4 全局访问限制
@@ -22,16 +22,32 @@ block eContent
             label.col-sm-2.control-label 白名单
             .col-sm-6
               .checkbox
-                label.m-r-05
-                  input(type='checkbox' disabled checked="true")
-                  span 证书 - 运维
-                label.m-r-05(v-for='cl in certList')
-                  input(type='checkbox' v-model="visitSettings.globalAccessLimit.whitelist" :value='cl.type')
-                  span {{cl.name}}
+                h5 证书
+                label.m-r-1(v-for='role in roles')
+                  input(type='checkbox' v-model="visitSettings.globalAccessLimit.whitelist.rolesId" :value='role._id')
+                  span {{role.displayName}}
+              .radio
+                h5 关系
+                label.m-r-1
+                  input(type='radio' v-model="visitSettings.globalAccessLimit.whitelist.relation" value='and')
+                  span 与
+                label
+                  input(type='radio' v-model="visitSettings.globalAccessLimit.whitelist.relation" value='or')
+                  span 或
+              .checkbox
+                h5 用户等级
+                label.m-r-1(v-for='grade in grades')
+                  input(type='checkbox' v-model="visitSettings.globalAccessLimit.whitelist.gradesId" :value='grade._id')
+                  span {{grade.displayName}}
           .form-group
-            label.col-sm-2.control-label 提示内容
+            label.col-sm-2.control-label 登录用户提示内容
             .col-sm-6
-              textarea.form-control(rows=5 v-model="visitSettings.globalAccessLimit.description")
+              textarea.form-control(rows=5 v-model="visitSettings.globalAccessLimit.userDescription")
+              span.text-info 支持空格和换行
+          .form-group
+            label.col-sm-2.control-label 游客提示内容
+            .col-sm-6
+              textarea.form-control(rows=5 v-model="visitSettings.globalAccessLimit.visitorDescription")
               span.text-info 支持空格和换行
           h4 游客全局访问限制
           .form-group

--- a/pages/forum/forum.js
+++ b/pages/forum/forum.js
@@ -210,6 +210,37 @@ function removeLastThreadPanel() {
   threadPanel.eq(length - 1).remove();
 }
 
+const formSearchApp = new Vue({
+  el: "#forumSearch",
+  data: {
+    content: '',
+    show: false,
+  },
+  methods: {
+    switchForumSearch() {
+      this.show = !this.show;
+    },
+    search() {
+      const {content} = this;
+      return Promise.resolve()
+        .then(() => {
+          if(content.length === 0) throw new Error("搜索内容不能为空");
+          return nkcAPI(`/f/${fid}/child?type=all`, 'GET')
+        })
+        .then((res) => {
+          const fid = res.forumsId;
+          const c = window.btoa(encodeURIComponent(content));
+          const d = window.btoa(encodeURIComponent(JSON.stringify({fid})));
+          const form = 'complex';
+          NKC.methods.visitUrl(`/search?c=${c}&d=${d}&form=${form}`, true);
+        })
+        .catch(err => {
+          screenTopWarning(err.message || err.error || err)
+        })
+    }
+  }
+});
+
 Object.assign(window, {
   threadUrlSwitchKey,
   modifyThreadUrl,
@@ -223,4 +254,5 @@ Object.assign(window, {
   createMouseEvents,
   setThreadListNewCount,
   removeLastThreadPanel,
+  formSearchApp,
 });

--- a/pages/forum/forum.less
+++ b/pages/forum/forum.less
@@ -1,3 +1,4 @@
+@import "../publicModules/base";
 body{
   /*background-color: #f4f4f4;*/
 }
@@ -260,6 +261,9 @@ body{
 }
 .forum-info-panel .forum-post-count{
   margin-top: 0.25rem;
+  height: 2rem;
+  line-height: 2rem;
+  .hideText(@line: 1);
 }
 .forum-info-panel .forum-post-count .count-group{
   display: inline-block;

--- a/pages/forum/forum.pug
+++ b/pages/forum/forum.pug
@@ -40,6 +40,10 @@ block content
     .row
       .col-xs-12.col-md-2.hidden-sm.hidden-xs.box-shadow-panel.p-r-0
         include ../publicModules/forums_nav/forums_tree
+        +renderForumsPanel("细分专业", data.forum.childrenForums)
+        +renderForumsPanel("同级专业", data.sameLevelForums)
+        +renderForumsBreadcrumb("上级专业", data.forumNav)
+        +renderForumsPanel("顶级专业", data.topForums)
       .col-xs-12.col-md-7.box-shadow-panel.p-r-0
         .forum-info-panel.m-b-1
           .forum-banner
@@ -99,6 +103,7 @@ block content
                   a.nav-link(href=`/f/${fid}${cid !== undefined ? `?cat=${cid}` : ''}` data-float-fid=fid)= name
               .thread-nav-right
                 if !data.forum.childrenForums || !data.forum.childrenForums.length
+                  button.btn.btn-xs.btn-default.m-r-05(onclick='formSearchApp.switchForumSearch()') 搜索本专业
                   if !data.user
                     button.forum-post-button.btn.btn-default.btn-xs(onclick='NKC.methods.toLogin()')
                       .fa.fa-pencil-square-o
@@ -119,6 +124,11 @@ block content
                   span 细分专业：
                   for f in data.forum.childrenForums
                     a.child-forum-panel(href=`/f/${f.fid}` data-float-fid=f.fid style=`background-color: ${f.color}`)= f.displayName
+                  button.btn.btn-xs.btn-default(onclick='formSearchApp.switchForumSearch()') 搜索本专业
+          .form.form-inline.m-t-1.text-right.forum-search#forumSearch(v-cloak v-if='show')
+            .form-group.m-b-05
+              input.form-control.m-b-05(placeholder="请输入关键词" type='text' v-model='content' @keyup.enter='search')
+              button.btn.btn-default.m-b-05(@click='search') 搜索
         //-if data.forum.childrenForums && data.forum.childrenForums.length
           .m-b-1
             .panel-header 细分专业

--- a/pages/home/home.pug
+++ b/pages/home/home.pug
@@ -10,6 +10,7 @@ block content
       include ../publicModules/checkDefaultUsername
       .col-xs-12.col-md-2.hidden-xs.hidden-sm#leftDom.box-shadow-panel.p-r-0
         include ../publicModules/forums_nav/forums_tree
+        +renderCategoryForums
       .col-xs-12.col-md-7.box-shadow-panel.p-r-0
         if !state.isApp && data.user && state.subForums.length
           .m-b-1

--- a/pages/interface_user_settings_apps.js
+++ b/pages/interface_user_settings_apps.js
@@ -71,6 +71,12 @@ function submit(uid) {
     })
 }
 
+function clearUserColor() {
+  const colorInput = $('input[data-control="selectColor"]');
+  colorInput.minicolors("value", "")
+  saveAppInfo();
+}
+
 // 检测是否已经购买过不打水印的服务
 function isAlreadyPay(info){
   if(!info){
@@ -277,5 +283,6 @@ Object.assign(window, {
   turnPictureImg,
   turnVideoImg,
   saveAppInfo,
+  clearUserColor,
   app,
 });

--- a/pages/interface_user_settings_apps.pug
+++ b/pages/interface_user_settings_apps.pug
@@ -114,6 +114,7 @@ block content
                 label.col-sm-2.control-label
                 .col-sm-9
                   button.btn.btn-primary.btn-sm(onclick="saveAppInfo()") 保存
+                  button.btn.btn-default.btn-sm(onclick="clearUserColor()") 恢复默认
         .panel.panel-default
           .panel-heading
             span 奖励设置

--- a/pages/publicModules/forums_nav/forums_tree.pug
+++ b/pages/publicModules/forums_nav/forums_tree.pug
@@ -12,6 +12,12 @@ style.
         background: #9baec8;
         color: #fff;
     }
+    .home-topic-item-div.bread-crumb a{
+      vertical-align: middle;
+    }
+    .home-topic-item-div.bread-crumb span{
+      vertical-align: middle;
+    }
 
 mixin renderForums(forums)
   for forum in forums
@@ -50,7 +56,7 @@ mixin renderSimpleForums(forums)
           span |
         a.forum-child(href=tools.getUrl('forumHome', cf.fid) data-float-fid=cf.fid style=`background-color: ${hexToRgba(cf.color, 0.1)}`)=cf.displayName
 
-if data.forum && data.forum.childrenForums && data.forum.childrenForums.length
+//-if data.forum && data.forum.childrenForums && data.forum.childrenForums.length
   .m-b-1
     .panel-header 细分专业
     .home-topic-item-div
@@ -118,14 +124,34 @@ if data.visitedForums && data.visitedForums.length
     .forum-block
       .forum-block-info
         a(href=`/?t=latest`).forum-block-name 最新文章
-if state.categoryForums
-  for fc in state.categoryForums
-    if fc.forums.length
-      .m-b-1
-        .panel-header(title=fc.description)=fc.name
-        if 1 || fc.displayStyle === 'simple'
-          +renderSimpleForums(fc.forums)
-        else
-          +renderForums(fc.forums)
+mixin renderCategoryForums
+  if state.categoryForums
+    for fc in state.categoryForums
+      if fc.forums.length
+        .m-b-1
+          .panel-header(title=fc.description)=fc.name
+          if 1 || fc.displayStyle === 'simple'
+            +renderSimpleForums(fc.forums)
+          else
+            +renderForums(fc.forums)
 
 
+mixin renderForumsPanel(name, forums)
+  if forums && forums.length
+    .m-b-1
+      .panel-header=name
+      .home-topic-item-div
+        for forum in forums
+          a(href=`/f/${forum.fid}` data-float-fid=forum.fid).forum-inline-name.forum-block-name=forum.displayName
+
+
+mixin renderForumsBreadcrumb(name, forums)
+  if forums && forums.length
+    .m-b-1
+      .panel-header=name
+      .home-topic-item-div.bread-crumb
+        a.forum-block-name.forum-inline-name(href='/?t=home' title=state.serverSettings.brief) 主页
+        for n in forums
+          -var {fid, name, cid} = n;
+          span.m-r-05 /
+          a.forum-block-name.forum-inline-name(href=`/f/${fid}${cid !== undefined ? `?cat=${cid}` : ''}` data-float-fid=fid)= name

--- a/pages/publicModules/navbar/navbar.pug
+++ b/pages/publicModules/navbar/navbar.pug
@@ -169,6 +169,7 @@ nav.navbar.navbar-default.navbar-fixed-top.nkcshade(style="min-height: 45px;marg
       //-include ../subscribeTypes/subscribeTypesPanel
       include ../apps/apps
       include ../forums_nav/forums_tree
+      +renderCategoryForums
 .nkc-drawer-right
   .nkc-drawer-right-mask(onclick="closeNKCDrawer('right')")
   .nkc-drawer-right-body

--- a/pages/search/search.js
+++ b/pages/search/search.js
@@ -109,6 +109,12 @@ var app = new Vue({
       NKC.methods.visitUrl("/search?c=" + this.strToBase64(this.c || "") + (this.t?"&t="+this.t:"") +"&d=" + this.options)
       // window.location.href = "/search?c=" + this.strToBase64(this.c || "") + (this.t?"&t="+this.t:"") +"&d=" + this.options;
     },
+    openComplexForm() {
+      if(this.complexOptions) {
+        return;
+      }
+      this.openMoreOptions();
+    },
     // 展开或者关闭更多搜索选项
     openMoreOptions: function() {
       var isOpen = this.complexOptions;
@@ -172,6 +178,9 @@ var app = new Vue({
     }
     if(NKC.modules.SubscribeTypes) {
       window.SubscribeTypes = new NKC.modules.SubscribeTypes();
+    }
+    if(data.form === 'complex') {
+      this.openComplexForm();
     }
   }
 });

--- a/pages/search/search.pug
+++ b/pages/search/search.pug
@@ -3,7 +3,7 @@ block title
   title=`搜索 - ${state.serverSettings.websiteName}`
   +includeCSS("/search/search.css")
 block content
-  #data.hidden=objToStr({c: data.c, t: data.t, d: data.d, selectedForums: data.selectedForums, excludedForums: data.excludedForums, threadCategories: data.threadCategories})
+  #data.hidden=objToStr({c: data.c, t: data.t, d: data.d, selectedForums: data.selectedForums, excludedForums: data.excludedForums, threadCategories: data.threadCategories, form: data.form})
   .container-fluid.max-width
     .row#app(v-cloak)
       .col-xs-12.col-md-9

--- a/routes/experimental/settings/visit/index.js
+++ b/routes/experimental/settings/visit/index.js
@@ -3,18 +3,23 @@ router
   .get('/', async (ctx, next) => {
     const {db, data} = ctx;
     data.visitSettings = await db.SettingModel.getSettings('visit');
+    data.certList = await db.RoleModel.getCertList(["dev"]);
     ctx.template = 'experimental/settings/visit/visit.pug';
     await next();
   })
   .put('/', async (ctx, next) => {
     const {db, body, nkcModules} = ctx;
-    const {globalLimitVisitor, userHomeLimitVisitor} = body.visitSettings;
-    nkcModules.checkData.checkString(globalLimitVisitor.description, {
-      name: '全局游客限制 - 提示内容',
+    const {globalLimitVisitor, userHomeLimitVisitor, globalAccessLimit} = body.visitSettings;
+    nkcModules.checkData.checkString(globalAccessLimit.description, {
+      name: '全局访问限制 - 提示内容',
       maxLength: 100000,
     });
     nkcModules.checkData.checkString(globalLimitVisitor.description, {
-      name: '用户名片页游客限制 - 提示内容',
+      name: '游客全局访问限制 - 提示内容',
+      maxLength: 100000,
+    });
+    nkcModules.checkData.checkString(globalLimitVisitor.description, {
+      name: '游客用户名片访问限制 - 提示内容',
       maxLength: 100000,
     });
     await db.SettingModel.updateOne({_id: 'visit'}, {
@@ -26,6 +31,11 @@ router
         "c.userHomeLimitVisitor": {
           status: !!userHomeLimitVisitor.status,
           description: userHomeLimitVisitor.description
+        },
+        "c.globalAccessLimit": {
+          status: !!globalAccessLimit.status,
+          description: globalAccessLimit.description,
+          whitelist: globalAccessLimit.whitelist
         }
       }
     });

--- a/routes/experimental/settings/visit/index.js
+++ b/routes/experimental/settings/visit/index.js
@@ -2,40 +2,52 @@ const router = require('koa-router')();
 router
   .get('/', async (ctx, next) => {
     const {db, data} = ctx;
+    data.roles = await db.RoleModel.find({_id: {$nin: ['default', 'dev']}}, {_id: 1, displayName: 1});
+    data.grades = await db.UsersGradeModel.find({}, {_id: 1, displayName: 1});
     data.visitSettings = await db.SettingModel.getSettings('visit');
-    data.certList = await db.RoleModel.getCertList(["dev"]);
     ctx.template = 'experimental/settings/visit/visit.pug';
     await next();
   })
   .put('/', async (ctx, next) => {
     const {db, body, nkcModules} = ctx;
-    const {globalLimitVisitor, userHomeLimitVisitor, globalAccessLimit} = body.visitSettings;
-    nkcModules.checkData.checkString(globalAccessLimit.description, {
-      name: '全局访问限制 - 提示内容',
+    const {userHomeLimitVisitor, globalAccessLimit} = body.visitSettings;
+    nkcModules.checkData.checkString(globalAccessLimit.userDescription, {
+      name: '全局访问限制 - 登录用户提示内容',
       maxLength: 100000,
     });
-    nkcModules.checkData.checkString(globalLimitVisitor.description, {
-      name: '游客全局访问限制 - 提示内容',
+    nkcModules.checkData.checkString(globalAccessLimit.visitorDescription, {
+      name: '全局访问限制 - 游客提示内容',
       maxLength: 100000,
     });
-    nkcModules.checkData.checkString(globalLimitVisitor.description, {
+    nkcModules.checkData.checkString(userHomeLimitVisitor.description, {
       name: '游客用户名片访问限制 - 提示内容',
       maxLength: 100000,
     });
+    const roles = await db.RoleModel.find({_id: {$nin: ['default', 'dev']}}, {_id: 1, displayName: 1});
+    const grades = await db.UsersGradeModel.find({}, {_id: 1, displayName: 1});
+    const rolesId = roles.map(r => r._id);
+    const gradesId = grades.map(g => g._id);
+    const {whitelist} = globalAccessLimit;
+    whitelist.rolesId = whitelist.rolesId.filter(id => rolesId.includes(id));
+    whitelist.gradesId = whitelist.gradesId.filter(id => gradesId.includes(id));
+    if(!['or', 'and'].includes(whitelist.relation)) {
+      ctx.throw(400, `全局访问限制白名单关系设置错误 relation=${whitelist.relation}`);
+    }
     await db.SettingModel.updateOne({_id: 'visit'}, {
       $set: {
-        "c.globalLimitVisitor": {
-          status: !!globalLimitVisitor.status,
-          description: globalLimitVisitor.description
-        },
         "c.userHomeLimitVisitor": {
           status: !!userHomeLimitVisitor.status,
           description: userHomeLimitVisitor.description
         },
         "c.globalAccessLimit": {
           status: !!globalAccessLimit.status,
-          description: globalAccessLimit.description,
-          whitelist: globalAccessLimit.whitelist
+          userDescription: globalAccessLimit.userDescription,
+          visitorDescription: globalAccessLimit.visitorDescription,
+          whitelist: {
+            relation: whitelist.relation,
+            rolesId: whitelist.rolesId,
+            gradesId: whitelist.gradesId
+          }
         }
       }
     });

--- a/routes/forum/singleForum.js
+++ b/routes/forum/singleForum.js
@@ -10,6 +10,7 @@ const cardRouter = require("./card");
 const Router = require('koa-router');
 const router = new Router();
 const nkcRender = require("../../nkcModules/nkcRender");
+const childRouter = require('./child');
 const customCheerio = require('../../nkcModules/nkcRender/customCheerio');
 router
 	.post('/', async (ctx, next) => {
@@ -184,6 +185,7 @@ router
 		const {today} = ctx.nkcModules.apiFunction;
 		// 能看到入口的专业id
 		const fidArr = await db.ForumModel.visibleFid(data.userRoles, data.userGrade, data.user, forum.fid);
+    const forumsIdCanShow = await db.ForumModel.visibleFid(data.userRoles, data.userGrade, data.user);
 		// 拿到能访问的专业id
 		const accessibleFid = await db.ForumModel.getAccessibleForumsId(data.userRoles, data.userGrade, data.user, forum.fid);
 		accessibleFid.push(fid);
@@ -290,8 +292,8 @@ router
 			}
 		} else {
 			// 拿到能看到入口的所有专业id
-			let visibleFidArr = await db.ForumModel.visibleFid(data.userRoles, data.userGrade, data.user);
-      visibleFidArr = visibleFidArr.filter(f => f !== forum.fid);
+			// let visibleFidArr = await db.ForumModel.visibleFid(data.userRoles, data.userGrade, data.user);
+      // visibleFidArr = visibleFidArr.filter(f => f !== forum.fid);
 			// 拿到能看到入口的顶级专业
 			// data.sameLevelForums = await db.ForumModel.find({parentsId: [], fid: {$in: visibleFidArr}});
 		}
@@ -299,6 +301,17 @@ router
 		// if(data.sameLevelForums && data.sameLevelForums.length){
 		// 	data.sameLevelForums = data.sameLevelForums.filter(c => c.fid !== forum.fid)
 		// }
+
+    data.topForums = await db.ForumModel.find({
+      parentsId: [],
+      fid: {
+        $in: forumsIdCanShow,
+      }
+    }, {
+      fid: 1,
+      displayName: 1,
+      description: 1
+    }).sort({order: 1});
 
 
 		data.subUsersCount = await db.SubscribeModel.countDocuments({cancel: false, fid, type: "forum"});
@@ -522,6 +535,7 @@ router
 	.use("/latest", latestRouter.routes(), latestRouter.allowedMethods())
 	.use('/followers', followerRouter.routes(), followerRouter.allowedMethods())
 	.use('/home', homeRouter.routes(), homeRouter.allowedMethods())
+  .use('/child', childRouter.routes(), childRouter.allowedMethods())
   .use("/library", libraryRouter.routes(), libraryRouter.allowedMethods());
 module.exports = router;
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -70,18 +70,59 @@ const path = require('path');
 router.use('/', async (ctx, next) => {
   const {data, state, db, nkcModules, settings} = ctx;
   const {user, operationId} = data;
+  const visitSettings = await db.SettingModel.getSettings('visit');
+  const isWhitelistOperation = settings.operationsType.whitelistOfVisitorLimit.includes(operationId);
+  const isResourceOperation = settings.operationsType.fileDownload.includes(operationId);
+  // 全局游客访问限制
+  // 未登录 且 不是白名单操作
   if(
-    !user &&
-    !settings.operationsType.whitelistOfVisitorLimit.includes(operationId)
+    !user && !isWhitelistOperation && visitSettings.globalLimitVisitor.status
   ) {
-    const visitSettings = await db.SettingModel.getSettings('visit');
-    if(visitSettings.globalLimitVisitor.status) {
+    if(!state.isApp) ctx.status = 401;
+    if(
+      isResourceOperation ||
+      (ctx.request.accepts('json', 'html') === 'json' && ctx.request.get('FROM') === 'nkcAPI')
+    ) {
+      return ctx.throw(403, visitSettings.globalLimitVisitor.description);
+    } else {
       data.description = nkcModules.nkcRender.plainEscape(visitSettings.globalLimitVisitor.description);
-      if(!state.isApp) ctx.status = 401;
-
-      return ctx.body = nkcModules.render(path.resolve(__dirname, '../pages/filter_visitor.pug'), data, state);
+      return ctx.body = nkcModules.render(path.resolve(__dirname, "../pages/filter_visitor.pug"), data, state);
     }
   }
+  // 全局访问限制
+  // 不是白名单
+  if(
+    !isWhitelistOperation && visitSettings.globalAccessLimit.status
+  ) {
+    let limit = true;
+    if(user) {
+      const userRoles = await user.extendRoles();
+      const grade = await user.extendGrade();
+      for(let i = 0; i < userRoles.length; i++) {
+        const roleId = userRoles[i]._id;
+        if(roleId === "dev" || visitSettings.globalAccessLimit.whitelist.includes(`role-${roleId}`)) {
+          limit = false;
+          break;
+        }
+      }
+      if(limit) {
+        limit = !visitSettings.globalAccessLimit.whitelist.includes(`grade-${grade._id}`);
+      }
+    }
+    if(limit) {
+      if(!state.isApp) ctx.status = 401;
+      if(
+        isResourceOperation ||
+        (ctx.request.accepts('json', 'html') === 'json' && ctx.request.get('FROM') === 'nkcAPI')
+      ) {
+        return ctx.throw(403, visitSettings.globalAccessLimit.description);
+      } else {
+        data.description = nkcModules.nkcRender.plainEscape(visitSettings.globalAccessLimit.description);
+        return ctx.body = nkcModules.render(path.resolve(__dirname, "../pages/filter_visitor.pug"), data, state);
+      }
+    }
+  }
+
   await next();
 });
 

--- a/routes/search/index.js
+++ b/routes/search/index.js
@@ -5,7 +5,7 @@ router
     const time = Date.now();
     const {db, data, query, nkcModules} = ctx;
     const {nkcRender} = nkcModules;
-    let {page=0, t, c, d} = query;
+    let {page=0, t, c, d, form = ''} = query;
     const {user} = data;
     // 通过mongodb精准搜索用户名
     let targetUser, existUser = false, searchUserFromMongodb = false;
@@ -23,6 +23,7 @@ router
     }
     data.t = t;
     data.d = d;
+    data.form = form;
     let options;
 
     // 高级搜索参数
@@ -31,10 +32,20 @@ router
         options = JSON.parse(decodeURIComponent(Buffer.from(d, "base64").toString()));
         const {fid, excludedFid} = options;
         if(fid && fid.length > 0) {
-          data.selectedForums = await db.ForumModel.find({fid: {$in: fid}});
+          data.selectedForums = await db.ForumModel.find({fid: {$in: fid}}, {
+            fid: 1,
+            displayName: 1,
+            color: 1,
+            avatar: 1,
+          }).sort({order: 1});
         }
         if(excludedFid &&excludedFid.length > 0) {
-          data.excludedForums = await db.ForumModel.find({fid: {$in: excludedFid}});
+          data.excludedForums = await db.ForumModel.find({fid: {$in: excludedFid}}, {
+            fid: 1,
+            displayName: 1,
+            color: 1,
+            avatar: 1,
+          }).sort({order: 1});
         }
         searchUserFromMongodb = !options.author;
       } catch(err) {

--- a/settings/operations/forum.js
+++ b/settings/operations/forum.js
@@ -5,6 +5,9 @@ module.exports = {
 		GET: 'visitForumHome', // 查看专业主页
 		POST: 'postToForum', // 在专业中发表文章
     DELETE: 'deleteForum', // 删除专业
+    child: {
+      GET: 'getForumChildForums'
+    },
     card: {
       GET: "visitForumCard"
     },

--- a/settings/operationsType.js
+++ b/settings/operationsType.js
@@ -72,6 +72,7 @@ module.exports = {
     "getMessageFile"
   ],
   whitelistOfVisitorLimit: [
+    'logout',
     'visitLogin',
     'submitLogin',
     'getRegisterCode',
@@ -106,6 +107,7 @@ module.exports = {
   fileDownload: [
     'getResources',
     'getAttachment',
+    'getSiteSpecific',
     'visitVerifiedUpload',
     'auditorVisitVerifiedUpload',
     'getMessageFile',


### PR DESCRIPTION
1. 添加全局访问限制；
2. 添加专业内搜索；
3. 专业主页左侧导航调整；
4. 用户偏好设置文章背景设置添加恢复默认功能；
5. 添加多域名支持；

更新步骤
1. 更新代码；
2. 在项目根目录执行 `npm run build-pages-p`；
3. 执行脚本 `modifyVisitSettings.js`；
4. 重启网站；
5. 后台管理 - 设置 - 证书，将 `getForumChildForums` 配置给 游客、普通会员、封禁用户；
6. 后台管理 - 设置 - 访问，调整全局访问限制相关设置；
