### PR TITLE
修复

### DIFF
--- a/pages/lib/vue/Editor.vue
+++ b/pages/lib/vue/Editor.vue
@@ -241,8 +241,12 @@
         });
       },
       initDomId() {
-        if(this.domId) return;
-        this.domId = `editor_id_${Date.now()}_${Math.round(Math.random() * 100000)}`;
+        const self = this;
+        return new Promise(resolve => {
+          if(self.domId) return resolve();
+          self.domId = `editor_id_${Date.now()}_${Math.round(Math.random() * 100000)}`;
+          self.$nextTick(resolve);
+        });
       },
       initEditor() {
         const self = this;


### PR DESCRIPTION
修复遨游浏览器打开社区回复评论编辑器报错的问题
更新步骤
1. 更新代码
2. 编译页面
3. 重启 nkc 服务