### PR TITLE
修复 APP 因监听点击网页链接而导致部分按钮失效的问题

### DIFF
--- a/pages/error/errorTemplate.pug
+++ b/pages/error/errorTemplate.pug
@@ -85,6 +85,7 @@ html(lang="zh-cn")
         padding: 0.5rem;
         border-radius: 2px;
         color: #31708f;
+        line-height: 2rem;
         margin-top: 0.5rem;
         background-color: #d9edf7;
         white-space: pre-wrap;

--- a/pages/global/event.js
+++ b/pages/global/event.js
@@ -11,7 +11,7 @@ import {
 import {getState} from "../lib/js/state";
 import {
   RNDownloadFile,
-  RNOpenNewPage, RNSaveImage,
+  RNOpenNewPageThrottle, RNSaveImage,
   RNUrlPathEval
 } from "../lib/js/reactNative";
 import {throttle} from "../lib/js/execution";
@@ -188,7 +188,7 @@ export function initAppGlobalClickLinkEvent() {
   if(!isReactNative) return;
   // 限流 限制点击链接最小间隔时间为300ms
   // 防止app同时打开多个相同的页面
-  const handle = throttle(function(e) {
+  const handle = function(e) {
     let element = e.target;
     let elementJQ = $(element);
     const tagName = element.nodeName.toLowerCase();
@@ -205,10 +205,8 @@ export function initAppGlobalClickLinkEvent() {
     if(!href) return;
     const title = elementJQ.attr('title') || '';
     const targetUrl = RNUrlPathEval(window.location.href, href);
-    RNOpenNewPage(targetUrl, title);
-  }, 300);
-  document.addEventListener('click', (e) => {
-    handle(e);
+    RNOpenNewPageThrottle(targetUrl, title);
     e.preventDefault();
-  });
+  }
+  document.addEventListener('click', handle);
 }

--- a/pages/lib/js/reactNative.js
+++ b/pages/lib/js/reactNative.js
@@ -195,6 +195,10 @@ export function RNOpenNewPage(url, title = '') {
   RNEmit('openNewPage', {href: url, title});
 }
 
+export const RNOpenNewPageThrottle = throttle(function(url, title = ''){
+  RNOpenNewPage(url, title);
+}, 100);
+
 /*
 * RN打开RN屏幕
 * @param {String} name 屏幕名


### PR DESCRIPTION
APP 监听到点击事件后未分情况一律执行了 e.preventDefault()，导致其他非链接的点击失效。

更新步骤
1. 更新代码；
2. 编译页面；
3. 重启 nkc 服务；