### PR TITLE
优化、调整

### DIFF
--- a/languages/zh_cn/operations.json
+++ b/languages/zh_cn/operations.json
@@ -305,6 +305,7 @@
   "logout": "退出登录",
   "manageOauthApp": "管理第三方应用",
   "manageQuestionTags": "管理考试系统试题标签",
+  "createQuestionTags": "创建考试系统试题标签",
   "manageZoneArticleCategory": "修改空间文章多维分类",
   "managementMoment": "管理电文",
   "managementNote": "管理所有笔记(屏蔽、编辑和删除)",

--- a/pages/lib/vue/PublicPaper.vue
+++ b/pages/lib/vue/PublicPaper.vue
@@ -439,6 +439,11 @@ export default Vue.extend({
         arr[i] = arr[index];
         arr[index] = n;
       }
+      const str = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'; // 一个包含所有字母的字符串
+      const alphabetArray = str.split(''); // 将字符串拆分为单个字母字符的数组
+      arr.forEach((a, index) => {
+        a.serialIndex = alphabetArray[index];
+      });
     },
     bgc(index,q){
       const isMultiple = this.question.isMultiple;

--- a/pages/lib/vue/QuestionTagSelector.vue
+++ b/pages/lib/vue/QuestionTagSelector.vue
@@ -119,7 +119,7 @@ export default {
     },
     title() {
       if(this.name === this.names.list) {
-        return '创建新标签';
+        return '选择标签';
       } else if(this.tag._id === null) {
         return '新建标签';
       } else {

--- a/routes/api/v1/exam/tags.js
+++ b/routes/api/v1/exam/tags.js
@@ -11,14 +11,14 @@ router
     ctx.apiData = {
       tags,
       manageQuestionTagsPermission: ctx.permission(
-        DynamicOperations.manageQuestionTags,
+        DynamicOperations.createQuestionTags,
       ),
     };
     await next();
   })
   .post(
     '/',
-    OnlyPermission(Operations.manageQuestionTags),
+    OnlyPermission(Operations.createQuestionTags),
     async (ctx, next) => {
       const { body } = ctx;
       const { name, desc } = body.tag;

--- a/services/exam/question.service.js
+++ b/services/exam/question.service.js
@@ -6,7 +6,6 @@ const { ResponseTypes } = require('../../settings/response');
 const { checkString } = require('../../nkcModules/checkData');
 const QuestionModel = require('../../dataModels/QuestionModel');
 const SettingModel = require('../../dataModels/SettingModel');
-const QuestionTagModel = require('../../dataModels/QuestionTagModel');
 const { userInfoService } = require('../user/userInfo.service');
 const { questionTagService } = require('./questionTag.service');
 const { defaultCerts } = require('../../settings/userCerts');
@@ -58,11 +57,11 @@ class QuestionService {
         checkString(item.text, {
           name: '选项内容',
           minLength: 1,
-          maxLength: 200,
+          maxLength: 2000,
         });
         checkString(item.desc, {
           name: '选项说明',
-          maxLength: 200,
+          maxLength: 2000,
         });
         if (item.correct) {
           hasCorrectAnswer = true;
@@ -82,11 +81,11 @@ class QuestionService {
       checkString(answer[0].text, {
         name: '答案内容',
         minLength: 1,
-        maxLength: 200,
+        maxLength: 2000,
       });
       checkString(answer[0].desc, {
         name: '答案说明',
-        maxLength: 200,
+        maxLength: 2000,
       });
     }
   }

--- a/settings/operations.js
+++ b/settings/operations.js
@@ -770,6 +770,7 @@ const DynamicOperations = {
   columnManage: 'columnManage',
   getThreadCategories: 'getThreadCategories',
   manageQuestionTags: 'manageQuestionTags',
+  createQuestionTags: 'createQuestionTags',
 };
 
 const Operations = { ...DynamicOperations, ...FixedOperations };


### PR DESCRIPTION
1. 修复开卷考试选项打乱后选项序号错乱的问题；
2. 调整试题标签的创建和管理权限；
3. 调整试题标签选择器的标题；
4. 调整试题内容的字数限制；

更新步骤
1. 更新代码；
2. 编译页面；
3. 重启 nkc, nkc-render 服务；