### PR TITLE
修复，调整

### DIFF
--- a/pages/lib/js/nkcSource.js
+++ b/pages/lib/js/nkcSource.js
@@ -349,7 +349,7 @@ export function renderCodeBlock() {
     span.innerText = languageName;
     const copyButton = document.createElement('button');
     copyButton.setAttribute('class', 'btn btn-default btn-xs');
-    copyButton.innerText = 'Copy';
+    copyButton.innerText = '复制';
     copyButton.onclick = () => {
       copyTextToClipboard(codeText)
         .then(() => {

--- a/pages/lib/vue/zone/views/Editor.vue
+++ b/pages/lib/vue/zone/views/Editor.vue
@@ -25,7 +25,7 @@ export default {
       return this.$route.query.id || '';
     },
     isEditMoment() {
-      return !!this.editMomentUrl;
+      return !!this.queryMomentId;
     },
   },
 };


### PR DESCRIPTION
更新内容：
1. 修复长电文编辑器页可能出现的文号缺失问题；
2. 调整代码块按钮文本；

更新步骤：
1. 更新代码；
2. 编译页面；
3. 重启 nkc, nkc-render 服务；